### PR TITLE
Add Output of Identifier to Bicep

### DIFF
--- a/03-Azure/01-03-Infrastructure/06_Migration_Datacenter_Modernization/resources/main.bicep
+++ b/03-Azure/01-03-Infrastructure/06_Migration_Datacenter_Modernization/resources/main.bicep
@@ -59,3 +59,7 @@ module destination 'destination.bicep' = [for i in range(0, deploymentCount): {
     deployment: (i+1)
   }
 }]
+
+
+output identifier string = suffix
+


### PR DESCRIPTION
Identifier is now output of the deployment:

`
"outputs": {
      "identifier": {
        "type": "String",
        "value": "xxxx"
}
`

Closes #95 