### PR TITLE
Add ARM Prameter Files to be ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -199,3 +199,6 @@ id_rsa
 id_rsa.pub
 *.private
 *.private.pub
+
+# Ignore ARM Parameter files
+*.parameters.json


### PR DESCRIPTION
Updating .gitignore to ignore *.parameter.json to avoid leakage of secrets.