### PR TITLE
Sovereign cloud enhancements

### DIFF
--- a/03-Azure/01-03-Infrastructure/01_Sovereign_Cloud/walkthrough/challenge-01/solution-01.md
+++ b/03-Azure/01-03-Infrastructure/01_Sovereign_Cloud/walkthrough/challenge-01/solution-01.md
@@ -158,7 +158,7 @@ RG_POLICY_DEFINITION_ID="e765b5de-1225-4ba3-bd56-1ac6695af988"
 az policy assignment create \
   --name "${ATTENDEE_ID}-restrict-rg-to-sovereign-regions" \
   --display-name "${DISPLAY_PREFIX} - Restrict Resource Groups to Sovereign Regions" \
-  --scope "/subscriptions/$SUBSCRIPTION_ID" \
+  --scope "/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP" \
   --policy "$RG_POLICY_DEFINITION_ID" \
   --params '{
     "listOfAllowedLocations": {


### PR DESCRIPTION
This pull request updates the scope of an Azure policy assignment in the `solution-01.md` walkthrough. The policy is now applied specifically to the target resource group instead of the entire subscription.

- Azure Policy Assignment Scope Change:
  * Modified the `az policy assignment create` command to set the `--scope` parameter to the specific resource group (`/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP`) instead of the whole subscription, ensuring the policy only affects the intended resource group.