### PR TITLE
Update AKS cluster creation command to specify node VM size

### DIFF
--- a/03-Azure/01-03-Infrastructure/01_Sovereign_Cloud/walkthrough/challenge-05/solution-05.md
+++ b/03-Azure/01-03-Infrastructure/01_Sovereign_Cloud/walkthrough/challenge-05/solution-05.md
@@ -135,7 +135,7 @@ az provider register --namespace Microsoft.ContainerService
 
 ```bash
 # Create an AKS cluster
-az aks create --resource-group $RESOURCE_GROUP --name $AKS_CLUSTER_NAME --node-count 1 --location $LOCATION --generate-ssh-keys
+az aks create --resource-group $RESOURCE_GROUP --name $AKS_CLUSTER_NAME --node-count 1 --location $LOCATION --generate-ssh-keys --node-vm-size Standard_D2s_v5
 
 # Connect to the cluster
 az aks get-credentials --resource-group $RESOURCE_GROUP --name $AKS_CLUSTER_NAME


### PR DESCRIPTION
This pull request makes a minor update to the AKS cluster creation command in the walkthrough documentation. The change specifies the VM size for the AKS node pool to ensure consistent environment setup.

* Documentation update:
  * [`03-Azure/01-03-Infrastructure/01_Sovereign_Cloud/walkthrough/challenge-05/solution-05.md`](diffhunk://#diff-60a2bade96be136835ece53e9e12f2f61945dd32f7535fbf75fb503ab7975ba7L138-R138): Added the `--node-vm-size Standard_D2s_v5` parameter to the `az aks create` command to explicitly set the VM size for the AKS cluster nodes.