### PR TITLE
Sovereign Cloud update

### DIFF
--- a/03-Azure/01-03-Infrastructure/01_Sovereign_Cloud/walkthrough/challenge-01/solution-01.md
+++ b/03-Azure/01-03-Infrastructure/01_Sovereign_Cloud/walkthrough/challenge-01/solution-01.md
@@ -438,6 +438,9 @@ Create a security group:
 az ad group create \
   --display-name "${GROUP_PREFIX}-SovereignOps-Team" \
   --mail-nickname "${GROUP_PREFIX}-SovereignOps"
+
+# Wait for eventual consistency
+sleep 20
 ```
 
 ### Step 2: Assign Built-in Roles to the SovereignOps Team
@@ -541,6 +544,9 @@ az role definition create --role-definition compliance-auditor-role.json
 az ad group create \
   --display-name "${GROUP_PREFIX}-Compliance-Officers" \
   --mail-nickname "${GROUP_PREFIX}-ComplianceOfficers"
+
+# Wait for eventual consistency
+sleep 20
 
 # Get the group's object ID
 COMPLIANCE_GROUP_ID=$(az ad group show --group "${GROUP_PREFIX}-Compliance-Officers" --query id -o tsv)


### PR DESCRIPTION
This pull request introduces a small but important change to the Azure infrastructure walkthrough documentation. A short delay has been added after Azure Active Directory group creation commands to account for eventual consistency in Azure's backend, helping to prevent issues when immediately referencing newly created groups in subsequent commands.

- Documentation reliability improvement:
  * Added a `sleep 20` command after each `az ad group create` invocation in `solution-01.md` to ensure group creation is fully propagated before proceeding. [[1]](diffhunk://#diff-07a342683dd49c0600e1bda184149d5a8aac8b97a082fabb53b6b15d957a7a2aR441-R443) [[2]](diffhunk://#diff-07a342683dd49c0600e1bda184149d5a8aac8b97a082fabb53b6b15d957a7a2aR548-R550)