### PR TITLE
Sovereign cloud updates

### DIFF
--- a/03-Azure/01-03-Infrastructure/01_Sovereign_Cloud/walkthrough/challenge-01/solution-01.md
+++ b/03-Azure/01-03-Infrastructure/01_Sovereign_Cloud/walkthrough/challenge-01/solution-01.md
@@ -111,8 +111,8 @@ The **"Allowed locations"** built-in policy restricts which locations users can 
 2. Click **Assignments** in the left menu
 3. Click **Assign policy**
 4. Configure the assignment:
-   - **Scope**: Select your subscription or resource group
-   - **Exclusions**: Leave empty (or exclude specific resource groups if needed)
+   - **Scope**: Select your resource group (e.g., `labuser-01`). **Do NOT select the subscription** — assigning at subscription scope will affect all other participants.
+   - **Exclusions**: Leave empty
    - **Policy definition**: Search for "Allowed locations"
    - **Assignment name**: Use the format "Lab User-{YourAttendeeNumber} - Restrict to Sovereign Regions" (e.g., "Lab User-01 - Restrict to Sovereign Regions")
    - **Description**: "Restrict all resource deployments to EU sovereign regions for data residency compliance"
@@ -273,6 +273,7 @@ Azure provides several policies to control public network access:
 2. Click **Assign policy**
 3. Search for "Not allowed resource types"
 4. Configure:
+   - **Scope**: Your resource group (e.g., `labuser-01`). **Do NOT select the subscription.**
    - **Assignment name**: "Block Public IP Addresses"
    - **Parameters**:
      - **Not allowed resource types**: Select `Microsoft.Network/publicIPAddresses`

--- a/03-Azure/01-03-Infrastructure/01_Sovereign_Cloud/walkthrough/challenge-03/solution-03.md
+++ b/03-Azure/01-03-Infrastructure/01_Sovereign_Cloud/walkthrough/challenge-03/solution-03.md
@@ -91,7 +91,7 @@ Goal: ensure all storage accounts enforce **Minimum TLS Version = TLS 1.2**.
 1. In the Azure Portal, navigate to **Policy**
 2. Select **Definitions**, search for **"Storage accounts should have the specified minimum TLS version"** (Policy ID `fe83a0eb-a853-422d-aac2-1bffd182c5d0`).
 3. Choose **Assign**.
-4. Set **Scope** to the subscription and your **Labuser-xxx** resource group.
+4. Set **Scope** to your **Labuser-xxx** resource group. **Do NOT select the subscription** — assigning at subscription scope will affect all other participants.
 5. Uncheck the box: **Only show parameters that need input or review**
 6. Under **Parameters**, set **Minimum TLS version** to `TLS 1.2` and (optionally) effect to `Deny`.
 7. Complete **Review + Create**, then select **Create**.


### PR DESCRIPTION
This pull request updates the Azure policy assignment instructions in the walkthrough documentation to clarify that policy assignments should be scoped only to the individual resource group (e.g., `labuser-01`) and not to the entire subscription. This prevents unintended impact on other participants in a shared environment.

Clarification of policy assignment scope:

* Updated instructions in `solution-01.md` to specify that the **"Allowed locations"** policy should be assigned at the resource group level, not the subscription, to avoid affecting other users.
* Added a note in `solution-01.md` under the "Not allowed resource types" policy to assign the policy at the resource group scope and not at the subscription.
* Modified `solution-03.md` to instruct users to set the scope for the "Storage accounts should have the specified minimum TLS version" policy to their resource group only, with an explicit warning not to select the subscription.