### PR TITLE
docs: fix common English typos

### DIFF
--- a/03-Azure/01-03-Infrastructure/04_BCDR_Azure_Native/walkthrough/challenge-01/solution-01.md
+++ b/03-Azure/01-03-Infrastructure/04_BCDR_Azure_Native/walkthrough/challenge-01/solution-01.md
@@ -37,7 +37,7 @@ Ask yourself the questions:
 1. Can I take an active part in the optimization process from the emergency plan? 
 2. Whom should I involve? 
 3. Do I have feedback from the application owners for the applications I am working with? 
-4. When was the last succesful failover in my organization? 
+4. When was the last successful failover in my organization? 
 5. Ask internally when the next failover is planned to test the disaster recovery plan.
 
 ### **Task 3: Put yourself in the position of an application owner and define the necessary steps to make sure your application stays available in case of a disaster**

--- a/03-Azure/01-03-Infrastructure/05_Azure_VMware_Solution/Challenges/01-NSX-DHCP.md
+++ b/03-Azure/01-03-Infrastructure/05_Azure_VMware_Solution/Challenges/01-NSX-DHCP.md
@@ -17,7 +17,7 @@ As a part of this challenge you are expected to <u>log on to the AVS Private clo
 
 ### Use Case Tip 
 
-VMs within the AVS environment will recieve IP from various sources 
+VMs within the AVS environment will receive IP from various sources 
 
 1. Some VMs may be migrated and they will retain their IPs from On-Prem to AVS if they are on an extended L2 stretch
 2. Some VMs may be migrated and they will need new IP from AVS if they are on a non-extended VLAN. in such cases the VM will get a new IP (DHCP based) or static IP

--- a/03-Azure/99-PreparationHelpers/Readme.md
+++ b/03-Azure/99-PreparationHelpers/Readme.md
@@ -6,7 +6,7 @@ The [Create Admin Users.ps1](../99-PreparationHelpers/Create%20Admin%20Users.ps1
 
 This script will perform the following actions:
 
-- Create 10 EntraID user accounts that will be used as dedicated Admin accounts for seperate MicroHacks
+- Create 10 EntraID user accounts that will be used as dedicated Admin accounts for separate MicroHacks
 - Create 6 EntraID groups that can be used to assign RBAC roles on the Azure Subscriptions
 
 You need to update line 7, 12 and 17 with your environment parameters.
@@ -15,7 +15,7 @@ You need to update line 7, 12 and 17 with your environment parameters.
 
 This script will perform the following actions:
 
-- Create 60 EntraID user accounts that will be used as dedicated MicroHack user accounts for seperate MicroHacks
+- Create 60 EntraID user accounts that will be used as dedicated MicroHack user accounts for separate MicroHacks
 - Assignes always 10 user accounts to the previously created groups
 
 You need to update line 8, 13 and 19 with your environment parameters.


### PR DESCRIPTION
## What

Fixes common English typos in documentation files.

## Changes

- `03-Azure/01-03-Infrastructure/05_Azure_VMware_Solution/Challenges/01-NSX-DHCP.md` — `recieve` → `receive` (1 occurrence)
- `03-Azure/99-PreparationHelpers/Readme.md` — `seperate` → `separate` (2 occurrences)
- `03-Azure/01-03-Infrastructure/04_BCDR_Azure_Native/walkthrough/challenge-01/solution-01.md` — `succesful` → `successful` (1 occurrence)

## Why

These are unambiguous English misspellings that slipped past review. The corrections are the widely-accepted English spellings:
- `recieve` / `recieved` / `recieving` → `receive` / `received` / `receiving` (common "ie"/"ei" reversal)
- `seperate` / `seperated` / `seperately` → `separate` / `separated` / `separately`
- `occured` / `occuring` / `occurence` → `occurred` / `occurring` / `occurrence`
- `begining` → `beginning`
- `succesful` / `succesfully` → `successful` / `successfully`
- `neccessary` → `necessary`
- `accomodate` → `accommodate`
- `overriden` → `overridden`
- `compatable` → `compatible`
- `cancelation` → `cancellation`
- `Pallete` → `Palette`

## Testing

- Documentation-only changes. No code affected.
- Each change is a literal one-word replacement. Diff is trivial to review.
