### PR TITLE
fix(12_Azure_Copilot): align lab content with real Azure Copilot behavior

### DIFF
--- a/03-Azure/01-03-Infrastructure/12_Azure_Copilot/Readme.md
+++ b/03-Azure/01-03-Infrastructure/12_Azure_Copilot/Readme.md
@@ -35,6 +35,8 @@ This MicroHack scenario walks through the use of Azure Copilot and its five spec
 
 Participants start by mastering Azure Copilot fundamentals (navigation, prompt writing, context management) and then progress through each agent's specialty before tackling a capstone challenge that combines all five agents in an end-to-end e-commerce platform scenario.
 
+The prompts in this lab are intentionally explicit so all participants get comparable Azure Copilot results. In real use, you can start with more conversational prompts and refine through follow-up questions; if Copilot asks for missing context such as region, time range, or resource selection, answer it and continue the workflow.
+
 ## Objectives
 
 After completing this MicroHack you will:
@@ -135,12 +137,12 @@ This creates five resource groups with pre-configured resources:
 
 The main cost drivers for this MicroHack are virtual machines and App Service:
 
-- **Challenge 4 (Optimization):** One Standard_D4s_v3 VM — approximately **$8/day**
-- **Challenge 5 (Resiliency):** One Standard_B2s VM — approximately **$1.50/day**
-- **Challenge 6 (Troubleshooting):** One Standard_B1s VM + Cosmos DB (Serverless) — approximately **$1.50/day**
-- **Challenge 3 (Observability):** App Service B1 plan — approximately **$0.50/day**
+- **Challenge 4 (Optimization):** One Standard_D4s_v3 Linux VM — approximately **$5–6/day**
+- **Challenge 5 (Resiliency):** One Standard_D2s_v3 Linux VM — approximately **$2.50–3/day**
+- **Challenge 6 (Troubleshooting):** One Standard_D2s_v3 Linux VM + Cosmos DB (Serverless) — approximately **$2.50–3.50/day**
+- **Challenge 3 (Observability):** App Service B1 plan — approximately **$0.50–2/day**
 
-Running all resources for one day costs approximately **$11.50–14**. For a 2-day workshop this would be approximately **$23–28 total**.
+The Challenge 5 and 6 VMs use D-series sizes rather than B-series sizes so the agent scenarios are not affected by burst-credit behavior. Costs vary by region, OS image, and actual usage. Running all resources for one day costs approximately **$11–15**. For a 2-day workshop this would be approximately **$22–30 total**.
 
 > [!TIP]
 > Delete all resources immediately after the workshop using `.\scripts\Remove-CopilotWorkshop.ps1 -Suffix "<suffix>"` to minimize costs.

--- a/03-Azure/01-03-Infrastructure/12_Azure_Copilot/challenges/challenge-01.md
+++ b/03-Azure/01-03-Infrastructure/12_Azure_Copilot/challenges/challenge-01.md
@@ -64,9 +64,9 @@ Use Azure Copilot to answer the following questions. Write your prompts and note
 Use Azure Copilot to navigate to different services and pages in the portal:
 
 1. Ask: _"Take me to the Virtual Machines page"_
-2. Ask: _"Open Azure Monitor"_
+2. Ask: _"Take me to the Azure Monitor overview page in the Azure portal."_
 3. Ask: _"Navigate to Cost Management"_
-4. Ask: _"Show me the Advisor recommendations page"_
+4. Ask: _"Take me to the Azure Advisor recommendations page in the Azure portal."_
 
 **Question to answer:** What happens when you ask Azure Copilot to navigate? Does it open the page directly or provide a link?
 
@@ -75,8 +75,8 @@ Use Azure Copilot to navigate to different services and pages in the portal:
 Ask Azure Copilot to generate scripts for common tasks:
 
 1. Ask: _"Generate an Azure CLI script to create a storage account named 'stcopilotworkshop' in the resource group 'rg-copilot-<suffix>-ch00' in East US 2"_
-2. Ask: _"Can you convert that to PowerShell?"_
-3. Ask: _"Generate a Bicep template to create a virtual network with two subnets"_
+2. Ask: _"Convert the following Azure CLI command to PowerShell, keeping the same storage account name, resource group, and region: az storage account create --name stcopilotworkshop<suffix> --resource-group rg-copilot-<suffix>-ch00 --location eastus2 --sku Standard_LRS"_
+3. Ask: _"Generate a Bicep template that creates a Virtual Network named `vnet-copilot-workshop` with address space `10.0.0.0/16` and two subnets: `subnet-app` (`10.0.1.0/24`) and `subnet-data` (`10.0.2.0/24`). Include parameters for the VNet name and location."_
 
 **Question to answer:** How does Azure Copilot handle multi-turn conversations? Does it remember context from your previous prompts?
 
@@ -84,10 +84,10 @@ Ask Azure Copilot to generate scripts for common tasks:
 
 Explore Azure Advisor integration:
 
-1. Ask: _"Show me my top cost recommendations"_
-2. Ask: _"What are my security recommendations?"_
-3. Ask: _"Show me my reliability recommendations"_
-4. Ask: _"What services do you recommend for building a web application with a database backend?"_
+1. Ask: _"List my top Azure Advisor cost recommendations for this subscription."_
+2. Ask: _"List my top Azure Advisor security recommendations for this subscription."_
+3. Ask: _"List my top Azure Advisor reliability recommendations for this subscription."_
+4. Ask: _"What Azure services do you recommend for building a web application with a relational database backend? Compare App Service + Azure SQL Database vs App Service + Azure Database for PostgreSQL Flexible Server, and summarize when each is appropriate."_
 
 **Question to answer:** Does Azure Copilot provide generic recommendations or ones tailored to your actual Azure environment?
 

--- a/03-Azure/01-03-Infrastructure/12_Azure_Copilot/challenges/challenge-02.md
+++ b/03-Azure/01-03-Infrastructure/12_Azure_Copilot/challenges/challenge-02.md
@@ -48,10 +48,10 @@ By the end of this challenge, you will be able to:
 
 The initial plan is good, but as the architect, you want to refine it. Use follow-up prompts to adjust:
 
-1. Ask: _"Can you add a Virtual Network with subnets for the App Service and the database?"_
-2. Ask: _"I want the PostgreSQL server to use private endpoints instead of public access."_
-3. Ask: _"Add a Network Security Group to restrict traffic to the App Service subnet."_
-4. Ask: _"What would be the estimated monthly cost for this setup at a basic tier?"_
+1. Ask: _"In the Deployment Agent plan canvas for the Flask+PostgreSQL workload, add a Virtual Network `10.0.0.0/16` with an App Service subnet `10.0.1.0/24` and a database subnet `10.0.2.0/24` delegated to PostgreSQL Flexible Server."_
+2. Ask: _"Revise the same NEW-workload design so PostgreSQL uses private access or private endpoints, and include the supporting DNS and networking considerations. Do not ask me to select existing resources."_
+3. Ask: _"Update the same NEW-workload design to include an NSG strategy for the application subnet. Describe the intended inbound and outbound restrictions rather than querying existing resources."_
+4. Ask: _"Provide a rough monthly cost estimate for the planned infrastructure (App Service Basic, PostgreSQL Flexible Server Standard_B1ms in the Burstable tier, Key Vault Standard, Application Insights, VNet) assuming East US 2 list prices."_
 
 **Question to answer:** How does the Deployment Agent handle these incremental refinements? Does it update the plan or start over?
 
@@ -84,7 +84,7 @@ When the plan is ready, Azure Copilot presents it as a summary with components, 
 
 1. After reviewing the infrastructure plan, click **"I approve the plan"** to proceed (or, if you described the workload via a prompt, ask Azure Copilot to generate the Terraform code):
 
-   > _"Generate the Terraform configurations for this plan."_
+   > _"Generate starter Terraform for a NEW Azure deployment of a Flask web app on App Service with PostgreSQL Flexible Server, Key Vault, and Application Insights. Include the main resources even if I still need to customize variables and networking details."_
 
 2. **Review the generated files** in the artifact pane:
    - Click the **maximize icon** to open the artifact pane
@@ -124,7 +124,7 @@ After reviewing the configurations, explore the available deployment methods:
 
 Start a **new conversation** and try a completely different deployment scenario:
 
-> _"Set up a multitenant SaaS application on AKS using Kubernetes namespaces for isolation, integrate Microsoft Entra for authentication, and centralize logs in Azure Log Analytics."_
+> _"Design a NEW workload plan for a multitenant SaaS application on AKS using Kubernetes namespaces for tenant isolation, Microsoft Entra ID for authentication, and Azure Log Analytics for centralized logging. Do not select an existing cluster — this is a greenfield design."_
 
 Compare the approach, plan, and generated configurations with your first scenario.
 

--- a/03-Azure/01-03-Infrastructure/12_Azure_Copilot/challenges/challenge-03.md
+++ b/03-Azure/01-03-Infrastructure/12_Azure_Copilot/challenges/challenge-03.md
@@ -99,7 +99,7 @@ You must have one of these roles on the Azure Monitor Workspace:
 3. Copy the alert's **resource ID** (found in the alert's properties/essentials section)
 4. Use this prompt (replace the ID with your actual alert ID):
 
-   > _"Start an investigation for my alert: `/subscriptions/{SUB_ID}/resourcegroups/{RG}/providers/microsoft.insights/components/{COMPONENT}/providers/Microsoft.AlertsManagement/alerts/{ALERT_ID}`"_
+   > _"If there are active Application Insights alerts in this subscription, investigate the most recent one and summarize the likely root cause. If there are no active alerts, explain how you would investigate one in this lab and what data you would analyze."_
 
 5. Click **"Show activity"** to watch the investigation progress in real time
 6. Review the investigation summary when complete
@@ -135,7 +135,7 @@ After the investigation completes, carefully review the results:
 4. **Follow the link** to the Azure Monitor issue for the full investigation details
 5. Ask follow-up questions:
 
-   > _"Can you explain more about finding #1?"_
+   > _"For the alert we just discussed (or for a typical App Insights alert if none exist), tell me what data you analyze, what findings you look for, and what remediation steps you would recommend."_
    > _"What would happen if I don't address this issue?"_
    > _"Are there any related alerts I should be aware of?"_
 
@@ -159,10 +159,11 @@ After the investigation completes, carefully review the results:
 
 Run through the complete workflow one more time with a different alert or a hypothetical scenario:
 
-1. Ask: _"What are the key alerts raised since the past 24 hours?"_
-2. Pick an alert from the list and ask for an investigation
-3. Review the results concisely
-4. Identify the remediation steps
+1. Ask: _"Summarize any Application Insights alerts raised in the past 24 hours. If none are present, say so clearly and tell me what traffic or failure signal I should generate for this lab."_
+2. Ask: _"Investigate the most important recent Application Insights alert. If there are no recent alerts, walk me through how I would investigate the next one and what remediation evidence I should capture."_  (if the first prompt returned no alerts, use this follow-up)
+3. Pick an alert from the list and ask for an investigation
+4. Review the results concisely
+5. Identify the remediation steps
 
 **Question to answer:** How would you integrate this investigation workflow into your daily on-call routine?
 

--- a/03-Azure/01-03-Infrastructure/12_Azure_Copilot/challenges/challenge-04.md
+++ b/03-Azure/01-03-Infrastructure/12_Azure_Copilot/challenges/challenge-04.md
@@ -63,7 +63,7 @@ If you already have VMs or VMSS in your subscription:
 1. Open Azure Copilot and **enable agent mode**
 2. Ask for a subscription-wide overview:
 
-   > _"Show me the top five cost-saving opportunities for subscription `{YOUR_SUBSCRIPTION_ID}`"_
+   > _"Show me my top Azure Advisor cost recommendations for this subscription."_
 
 3. Review the list of recommendations. For each one, note:
    - The resource affected
@@ -71,7 +71,7 @@ If you already have VMs or VMSS in your subscription:
    - The estimated monthly savings
 4. Try a broader query:
 
-   > _"Summarize total potential cost and carbon reduction from all active recommendations."_
+   > _"Summarize total potential monthly savings from all active Azure Advisor cost recommendations, grouped by category (VM rightsizing, reserved instances, idle resources)."_
 
 **Question to answer:** What categories of cost savings does the Optimization Agent identify? How significant are the potential savings?
 
@@ -81,7 +81,7 @@ Pick one recommendation from Task 1 and explore it in detail:
 
 1. Ask for more details:
 
-   > _"Explain the recommendation for `vm-copilot-oversized`."_
+   > _"Give me detailed rightsizing analysis for VM `vm-copilot-oversized` in resource group `rg-copilot-<suffix>-ch03`: current SKU, recommended SKU, average CPU and memory utilization, estimated monthly savings, and performance impact."_
 
 2. Understand the reasoning:
    - What metrics indicate the resource is underutilized?
@@ -90,7 +90,7 @@ Pick one recommendation from Task 1 and explore it in detail:
 
 3. Request an alternative:
 
-   > _"Is there an alternate recommendation for `vm-copilot-oversized`?"_
+   > _"Explain why Azure Advisor recommends resizing `vm-copilot-oversized` from its current SKU to the smaller SKU. Include the utilization data and the threshold rules Advisor uses."_
 
 4. Compare the options:
    - Original recommendation vs. alternative
@@ -102,14 +102,14 @@ Pick one recommendation from Task 1 and explore it in detail:
 
 1. Ask Azure Copilot to show you the expected impact visually:
 
-   > _"Show me a chart of the expected results of applying the recommendation for `vm-copilot-oversized`."_
+   > _"Generate a bar chart comparing the current monthly cost and the recommended monthly cost for `vm-copilot-oversized` after applying the Advisor rightsizing recommendation, and show the % savings."_
 
 2. Review the generated chart:
    - What metrics are shown (CPU, memory, cost)?
    - How does current usage compare to the recommended tier?
 3. Ask for a subscription-level summary:
 
-   > _"Can you show me a breakdown of potential savings by resource type for my subscription?"_
+   > _"Give me a subscription-level optimization summary: total potential monthly savings, breakdown by resource type (VMs, storage, databases), and the top 3 recommendations by impact."_
 
 **Question to answer:** How do the visual charts help you communicate optimization plans to management or stakeholders?
 
@@ -119,7 +119,7 @@ Generate scripts to implement the recommended changes:
 
 1. Ask for a PowerShell script:
 
-   > _"Generate a PowerShell script to apply the recommended optimizations for `vm-copilot-oversized`."_
+   > _"Generate a PowerShell script to resize VM `vm-copilot-oversized` in resource group `rg-copilot-<suffix>-ch03` from Standard_D4s_v3 to Standard_D2s_v3. Include stop, resize, and start steps."_
 
 2. Review the generated script:
    - Does it resize the VM?
@@ -128,7 +128,7 @@ Generate scripts to implement the recommended changes:
 
 3. Ask for a CLI version:
 
-   > _"Can you provide a CLI script to apply those optimizations?"_
+   > _"Now generate the equivalent Azure CLI (bash) script to resize `vm-copilot-oversized` in `rg-copilot-<suffix>-ch03` from Standard_D4s_v3 to Standard_D2s_v3 (deallocate, resize, start)."_
 
 4. Compare the two scripts — note the differences in syntax and approach
 

--- a/03-Azure/01-03-Infrastructure/12_Azure_Copilot/challenges/challenge-05.md
+++ b/03-Azure/01-03-Infrastructure/12_Azure_Copilot/challenges/challenge-05.md
@@ -39,7 +39,7 @@ Resources in **`rg-copilot-<suffix>-ch04`** (in your chosen deployment region):
 
 | Resource        | Name                      | SKU          | Resiliency Gaps                                |
 | --------------- | ------------------------- | ------------ | ---------------------------------------------- |
-| Virtual Machine | `vm-copilot-noresilience` | Standard_B2s | No zone redundancy, no Azure Backup configured |
+| Virtual Machine | `vm-copilot-noresilience` | Standard_D2s_v3 | No zone redundancy, no Azure Backup configured |
 
 > **Why these gaps?** The VM is intentionally deployed **without** availability zone configuration and **without** backup protection, so the Resiliency Agent will flag both issues and guide you through remediation.
 
@@ -67,7 +67,7 @@ Ensure you have resources deployed that can be evaluated for resiliency. Ideal r
 
 3. Then check at the service group level:
 
-   > _"Which service groups are currently not zone-resilient?"_
+   > _"Group any non-zone-resilient resources by service type and summarize the biggest resiliency gaps."_
 
 4. For a specific resource, ask for details:
 
@@ -86,7 +86,7 @@ Pick a non-zone-resilient resource and configure it:
 
 1. Ask Azure Copilot to help configure zone resiliency:
 
-   > _"Configure zone resiliency for my VM `vm-copilot-noresilience`."_
+   > _"For VM `vm-copilot-noresilience`, explain what would be required to improve resiliency and generate a starter script or command sequence if the service supports it. If not, give the manual steps."_
 
 2. Review the generated script:
    - What changes will it make?
@@ -95,7 +95,7 @@ Pick a non-zone-resilient resource and configure it:
 
 3. For resources where scripts aren't auto-generated, ask for guidance:
 
-   > _"How do I configure zone resiliency for my Azure Cache for Redis?"_
+   > _"What are the cost implications of enabling zone redundancy for a Standard_D2s_v3 VM, an App Service Standard S1 plan, and a Standard C1 Redis cache? Include any tier upgrades required."_
    > _"What are the steps to make my App Service zone-redundant?"_
 
 4. Understand the cost implications:
@@ -120,7 +120,7 @@ Pick a non-zone-resilient resource and configure it:
 
 4. Identify unprotected resources:
 
-   > _"Which VMs don't have Azure Backup configured?"_
+   > _"List virtual machines in this subscription that don't have an Azure Backup policy configured."_
 
 5. For any identified gaps, ask for remediation:
 
@@ -134,11 +134,13 @@ Use the Resiliency Agent to manage backup infrastructure:
 
 1. **Create a vault:**
 
-   > _"Help me create a Recovery Services vault named `rsv-copilot-workshop` in my resource group `rg-copilot-<suffix>-ch04`."_
+   > _"Create a Recovery Services vault named `rsv-copilot-workshop` in resource group `rg-copilot-<suffix>-ch04` with soft delete enabled. Show me the CLI or PowerShell commands."_
+   >
+   > Then, as a follow-up prompt: _"Now show me how to enable immutability on that vault (separate configuration step after creation)."_
 
 2. **Enhance vault security:**
 
-   > _"Increase the security level of this vault."_
+   > _"Outline a disaster recovery plan for the resources in rg-copilot-<suffix>-ch04: primary region, secondary region, RTO/RPO targets, and services needed (ASR, geo-backup, multi-region writes)."_
 
 3. **Explore vault operations:**
 
@@ -162,7 +164,7 @@ Bring it all together with a comprehensive assessment:
 
 2. Request a prioritized improvement plan:
 
-   > _"What are the top resiliency improvements I should make, prioritized by risk?"_
+   > _"Generate a prioritized resiliency improvement plan for rg-copilot-<suffix>-ch04. Order the items by risk (Critical, High, Medium, Low), cover zone resiliency, backup coverage, vault security, and DR, and include one concrete action per item."_
 
 3. Document the findings in a format suitable for the compliance audit:
 

--- a/03-Azure/01-03-Infrastructure/12_Azure_Copilot/challenges/challenge-06.md
+++ b/03-Azure/01-03-Infrastructure/12_Azure_Copilot/challenges/challenge-06.md
@@ -14,7 +14,7 @@ The Troubleshooting Agent helps you **resolve issues faster** by running diagnos
 
 Use the Troubleshooting Agent in Azure Copilot to diagnose resource issues, run root cause analysis, apply one-click fixes, and create support requests when needed.
 
-**Scenario:** You are the platform engineer at Contoso Ltd. Your team's Monday morning starts with several reports: a developer can't connect to a VM, the Cosmos DB (NoSQL API) is returning connection timeouts, and an AKS cluster is showing pod health issues. You need to quickly diagnose and resolve these issues before the business day starts.
+**Scenario:** You are the platform engineer at Contoso Ltd. Your team's Monday morning starts with several reports: a developer can't connect to a VM, the Cosmos DB (NoSQL API) is returning connection timeouts, and another team asks how to diagnose an AKS cluster that is showing pod health issues. You need to quickly diagnose, resolve, or advise on these issues before the business day starts.
 
 By the end of this challenge, you will be able to:
 
@@ -23,7 +23,7 @@ By the end of this challenge, you will be able to:
 - Apply one-click fixes offered by Azure Copilot
 - Follow step-by-step remediation instructions
 - Create support requests through Azure Copilot when needed
-- Troubleshoot across different resource types (VMs, Cosmos DB, AKS)
+- Troubleshoot across different resource types (VMs, Cosmos DB, and optional AKS guidance)
 
 ## Actions
 
@@ -93,7 +93,7 @@ Simulate a Cosmos DB connection issue investigation:
 1. Start a new conversation with agent mode enabled
 2. Describe the scenario:
 
-   > _"I'm trying to connect to my Azure Cosmos DB (NoSQL API) from my local development machine, but I keep getting a timeout. What should I do?"_
+   > _"I'm connecting to Azure Cosmos DB (NoSQL API) and getting connection failures. Give me a troubleshooting checklist covering firewall or IP allow-list, private endpoint/DNS, auth keys, TLS, and service health. If you need a resource, tell me what to select."_
 
 3. If you have a Cosmos DB account, select it when prompted. Otherwise, observe the general guidance provided
 4. Review the diagnostic steps:
@@ -111,17 +111,17 @@ Simulate a Cosmos DB connection issue investigation:
 
 **Question to answer:** How does the Troubleshooting Agent handle issues where it can't access the resource directly? Does it still provide useful guidance?
 
-### Task 3: Troubleshoot AKS Cluster Issues (10 min)
+### Task 3: Explore AKS Troubleshooting Guidance (No Cluster Required) (10 min)
 
 > [!NOTE]
 > No AKS cluster is deployed as part of the lab. This task is exploratory — you can select an existing AKS cluster in your subscription, or simply follow the prompts to see what guidance Azure Copilot provides without a specific resource selected.
 
-Investigate Kubernetes cluster problems:
+Walk through a Kubernetes cluster troubleshooting playbook:
 
 1. Start a new conversation with agent mode enabled
 2. Try these troubleshooting prompts (select your AKS cluster when prompted, or get general guidance):
 
-   > _"Investigate the health of my pods."_
+   > _"Explain how you would diagnose an AKS cluster that is not scheduling pods. List the checks you would run (node status, taints, resource quotas, pending pods) and the kubectl commands required. No cluster needs to be deployed."_
 
    > _"Investigate networking issues causing pod connectivity failures."_
 
@@ -148,7 +148,7 @@ The Troubleshooting Agent can sometimes provide one-click fixes:
 
 2. Ask Azure Copilot for help:
 
-   > _"My VM `vm-copilot-broken` isn't responding. Help me troubleshoot."_
+   > _"I have a VM `vm-copilot-broken` that won't start. Diagnose the likely causes first, and if Azure Copilot supports it, offer the exact one-click fix or portal action to use."_
 
 3. If Azure Copilot identifies a simple fix (e.g., the VM is stopped):
    - It will offer a **one-click fix** button
@@ -168,7 +168,7 @@ When the Troubleshooting Agent can't resolve an issue, it can create a support r
 
 1. Present a complex problem:
 
-   > _"My application is experiencing intermittent failures that I can't diagnose. Can you create a support request?"_
+   > _"Create a support request for a persistent VM boot issue on `vm-copilot-broken`. Include the symptoms, business impact, and the diagnostics I should attach before submitting."_
 
    Or more directly:
 
@@ -193,7 +193,7 @@ When the Troubleshooting Agent can't resolve an issue, it can create a support r
 
 - You used the Troubleshooting Agent to diagnose at least one VM issue
 - You investigated a database or application connectivity issue
-- You explored AKS or another resource type troubleshooting
+- You explored AKS troubleshooting guidance or another resource type troubleshooting
 - You experienced or understood the one-click fix capability
 - You explored the support request creation flow
 - You understand when the agent escalates from self-service to support
@@ -204,7 +204,7 @@ When the Troubleshooting Agent can't resolve an issue, it can create a support r
 - **Root cause diagnostics** are environment-specific — the agent analyzes your actual resource configuration and metrics
 - **One-click fixes** are available for common, well-understood issues — they require your confirmation before applying
 - When self-service resolution isn't possible, **support request creation** is seamless with pre-populated diagnostic data
-- The agent is especially effective for **Cosmos DB, VMs, and AKS** but works with all resource types
+- The agent is especially effective for **Cosmos DB and VMs** in this lab, and can also guide **AKS** troubleshooting when a cluster is available
 - [Troubleshooting Agent documentation](https://learn.microsoft.com/en-us/azure/copilot/troubleshooting-agent)
 
 **Limitations to Note:**

--- a/03-Azure/01-03-Infrastructure/12_Azure_Copilot/challenges/challenge-07.md
+++ b/03-Azure/01-03-Infrastructure/12_Azure_Copilot/challenges/challenge-07.md
@@ -37,7 +37,7 @@ By the end of this challenge, you will be able to:
 1. Open Azure Copilot with **agent mode enabled**
 2. Describe the full workload:
 
-   > _"I need to deploy an e-commerce platform with the following components: a React frontend on App Service, a Node.js backend API on App Service, Azure Cosmos DB for the product catalog, Azure Cache for Redis for session management, Azure CDN for static assets, Application Insights for monitoring, and Azure Key Vault for secrets. All resources should be in East US 2 with a Virtual Network."_
+   > _"Using the Deployment Agent, plan a 3-tier web application in East US 2 that includes: App Service (Standard S1) for the frontend, Azure Cosmos DB (NoSQL API, serverless) for the product catalog, Azure Cache for Redis (Basic C0), Application Insights, Key Vault, and a Virtual Network with separate subnets for App, Data, and Cache tiers. After the plan is shown, open the plan canvas (look for a button such as View plan / Open plan canvas / View workload)."_
 
 3. **Review** the workload plan Azure Copilot generates:
    - Does it include all requested components?
@@ -69,7 +69,7 @@ By the end of this challenge, you will be able to:
 
 1. In the **same or new conversation** (agent mode), ask about monitoring setup:
 
-   > _"What alerts should I configure for my e-commerce platform? I need to monitor the App Service, Cosmos DB, Redis Cache, and CDN."_
+   > _"Recommend the key metrics and alert rules I should configure for a 3-tier web app (App Service + Cosmos DB + Redis + Front Door). For each, specify the metric, suggested threshold, severity, and scope."_
 
 2. Review the suggested alert rules:
    - Response time thresholds
@@ -88,7 +88,7 @@ By the end of this challenge, you will be able to:
 
 4. Understand the investigation workflow:
 
-   > _"Walk me through your complete investigation process for a slow response time alert on my App Service."_
+   > _"For a production web app alert (HTTP 5xx spike), walk me through the incident response flow using Azure Copilot: (1) triage the alert, (2) investigate root cause, (3) apply remediation, (4) create a support request if needed. Include the exact prompts I would use at each step."_
 
 **Checkpoint:**
 
@@ -104,7 +104,7 @@ By the end of this challenge, you will be able to:
 
 1. Ask for a cost assessment:
 
-   > _"Show me cost-saving opportunities across my subscription. Focus on compute and database resources."_
+   > _"Using Azure Advisor, list the top reserved instance / savings plan recommendations for this subscription. Include resource type, commitment term, estimated monthly savings, and upfront vs monthly payment options."_
 
 2. Explore specific recommendations:
 
@@ -137,7 +137,7 @@ By the end of this challenge, you will be able to:
 
 1. Assess the resiliency posture:
 
-   > _"Which of my e-commerce platform resources aren't zone-resilient?"_
+   > _"Assess the resiliency posture for the e-commerce platform design you just planned (App Service + Cosmos DB + Redis + Front Door + Key Vault). Cover: zone resiliency, backup coverage, vault security, and multi-region DR. Give me a prioritized (Critical/High/Medium) improvement plan with one action per item."_
 
 2. Configure backup:
 
@@ -204,7 +204,7 @@ By the end of this challenge, you will be able to:
 
 1. Ask Azure Copilot to help create a runbook:
 
-   > _"Based on everything we've discussed about our e-commerce platform, help me create a daily operational runbook that covers monitoring, cost management, resiliency checks, and incident response."_
+   > _"Draft a daily/weekly/monthly operational runbook for a 3-tier web app in Azure. For each cadence, list 3–5 specific Copilot prompts I should run, covering deployment, monitoring, cost, resiliency, and incident response. Format as markdown."_
 
 2. Review and refine the runbook with follow-up questions:
 

--- a/03-Azure/01-03-Infrastructure/12_Azure_Copilot/iac/modules/ch04-resiliency.bicep
+++ b/03-Azure/01-03-Infrastructure/12_Azure_Copilot/iac/modules/ch04-resiliency.bicep
@@ -11,7 +11,8 @@ param sshPublicKey string
 param adminUsername string = 'azureuser'
 
 var vmName = 'vm-copilot-noresilience'
-var vmSize = 'Standard_B2s'
+// D-series avoids B-series burst credit behavior that can make Copilot recommendations nondeterministic.
+var vmSize = 'Standard_D2s_v3'
 
 var tags = {
   CostControl: 'Ignore'

--- a/03-Azure/01-03-Infrastructure/12_Azure_Copilot/iac/modules/ch05-troubleshooting.bicep
+++ b/03-Azure/01-03-Infrastructure/12_Azure_Copilot/iac/modules/ch05-troubleshooting.bicep
@@ -136,7 +136,8 @@ resource vm 'Microsoft.Compute/virtualMachines@2024-07-01' = {
   tags: tags
   properties: {
     hardwareProfile: {
-      vmSize: 'Standard_B1s'
+      // D-series avoids B-series burst credit behavior that can make Copilot recommendations nondeterministic.
+      vmSize: 'Standard_D2s_v3'
     }
     osProfile: {
       computerName: vmName

--- a/03-Azure/01-03-Infrastructure/12_Azure_Copilot/walkthrough/solution-01.md
+++ b/03-Azure/01-03-Infrastructure/12_Azure_Copilot/walkthrough/solution-01.md
@@ -56,23 +56,31 @@ Azure Copilot provides **Azure-specific, contextual guidance** that is grounded 
 
 ## Task 3: Navigate Using Azure Copilot
 
+> 💡 **Tip — reset between prompts:** before each navigation prompt, click the **Microsoft Azure** banner in the top-left to return to the portal home blade. Copilot replies with "you are already on that page" when the portal is already there, which is a valid outcome but harder to recognize as a navigation success.
+
 ### Steps
 
 **Prompt 1:** _"Take me to the Virtual Machines page"_
 
-> **Expected:** Azure Copilot provides a direct link to the Virtual Machines blade in the portal. Clicking the link navigates you there.
+> **Expected:** Azure Copilot either (a) provides a direct link to the Virtual Machines blade (clicking navigates you there), or (b) — if you are already on that blade — confirms you are already on the Virtual Machines page. Both are acceptable outcomes.
 
-**Prompt 2:** _"Open Azure Monitor"_
+**Prompt 2:** _"Take me to the Azure Monitor overview page in the Azure portal."_
 
-> **Expected:** Azure Copilot provides a link or directly navigates to the Azure Monitor overview page.
+> - Azure Copilot navigates directly to Azure Monitor or returns a clickable portal link to the Azure Monitor overview page.
+> - The Copilot pane may close or lose focus after navigation; participants may need to reopen it for the next step.
+> - If direct navigation is not available in that moment, Copilot should still provide a clear portal link rather than a generic service explainer.
+> - The key success signal is reaching the Azure Monitor blade, not receiving a long descriptive answer.
 
 **Prompt 3:** _"Navigate to Cost Management"_
 
 > **Expected:** Azure Copilot opens or links to the Cost Management + Billing blade.
 
-**Prompt 4:** _"Show me the Advisor recommendations page"_
+**Prompt 4:** _"Take me to the Azure Advisor recommendations page in the Azure portal."_
 
-> **Expected:** Azure Copilot provides a link to the Azure Advisor recommendations overview.
+> - Azure Copilot navigates to Azure Advisor recommendations or returns a direct portal link to that page.
+> - The response should clearly target Azure Advisor, not Metrics Advisor or a generic recommendation explanation.
+> - The Copilot pane may close or shift context after navigation, so reopening Copilot is acceptable for the next task.
+> - The successful outcome is that the participant reaches the Advisor recommendations experience in the portal.
 
 ### Answer
 
@@ -97,22 +105,19 @@ When you ask Azure Copilot to navigate, it typically **provides a clickable link
 >   --kind StorageV2
 > ```
 
-**Prompt 2:** _"Can you convert that to PowerShell?"_
+**Prompt 2:** _"Convert the following Azure CLI command to PowerShell, keeping the same storage account name, resource group, and region: az storage account create --name stcopilotworkshop<suffix> --resource-group rg-copilot-<suffix>-ch00 --location eastus2 --sku Standard_LRS"_
 
-> **Expected response (similar to):**
->
-> ```powershell
-> New-AzStorageAccount `
->   -ResourceGroupName "rg-copilot-<suffix>-ch00" `
->   -Name "stcopilotworkshop" `
->   -Location "eastus2" `
->   -SkuName "Standard_LRS" `
->   -Kind "StorageV2"
-> ```
+> - Azure Copilot returns a starter PowerShell example using `New-AzStorageAccount` or an equivalent Azure PowerShell workflow.
+> - The response keeps the same storage account name, resource group, and region from the restated command.
+> - The answer may include prerequisite notes such as signing in with `Connect-AzAccount` or selecting the correct subscription.
+> - Participants should expect better reliability when they restate critical context instead of relying on multi-turn memory alone.
 
-**Prompt 3:** _"Generate a Bicep template to create a virtual network with two subnets"_
+**Prompt 3:** _"Generate a Bicep template that creates a Virtual Network named `vnet-copilot-workshop` with address space `10.0.0.0/16` and two subnets: `subnet-app` (`10.0.1.0/24`) and `subnet-data` (`10.0.2.0/24`). Include parameters for the VNet name and location."_
 
-> **Expected:** Azure Copilot generates a complete Bicep template with a VNet and two subnet resources, including parameters for names and address prefixes.
+> - Azure Copilot returns a starter Bicep snippet for a VNet and two subnets in a single file or code block.
+> - The template may be minimal and may require the participant to adjust address ranges, parameterization, or naming before deployment.
+> - A concise example is acceptable; the response does not need to be a production-ready module set.
+> - The main success criterion is that Copilot produces recognizable Bicep syntax for the requested network structure.
 
 ### Answer
 
@@ -124,21 +129,30 @@ Azure Copilot **retains context** across a conversation. When you ask "convert t
 
 ### Steps
 
-**Prompt 1:** _"Show me my top cost recommendations"_
+**Prompt 1:** _"List my top Azure Advisor cost recommendations for this subscription."_
 
-> **Expected:** Azure Copilot returns a list of Azure Advisor cost recommendations for your subscriptions, including links to each recommendation.
+> - Azure Copilot often starts by summarizing the highest-cost services or current spend drivers in your subscription.
+> - If Azure Advisor cost recommendations are available, Copilot may surface some of them, but that is not guaranteed for every subscription.
+> - A spend-oriented answer is still useful because it highlights where to investigate savings first.
+> - Participants should treat this step as an entry point into cost analysis, not a guaranteed list of actionable Advisor recommendations.
 
-**Prompt 2:** _"What are my security recommendations?"_
+**Prompt 2:** _"List my top Azure Advisor security recommendations for this subscription."_
 
-> **Expected:** Azure Copilot lists security-related Advisor recommendations.
+> **Expected:** Azure Copilot lists security-related Advisor recommendations scoped to the current subscription — impacted resource, impact (High/Medium/Low), and a link to details for each item.
 
-**Prompt 3:** _"Show me my reliability recommendations"_
+**Prompt 3:** _"List my top Azure Advisor reliability recommendations for this subscription."_
 
-> **Expected:** Azure Copilot shows reliability-focused recommendations from Azure Advisor.
+> - Copilot either lists Azure Advisor reliability recommendations inline, OR
+> - Provides a link / navigates to the Advisor Reliability blade where recommendations are shown
+> - If inline, each item shows impacted resource, impact, and a link to details
+> - If the subscription has no qualifying workloads, Copilot may say "no reliability recommendations" — this is still a pass.
 
-**Prompt 4:** _"What services do you recommend for building a web application with a database backend?"_
+**Prompt 4:** _"What Azure services do you recommend for building a web application with a relational database backend? Compare App Service + Azure SQL Database vs App Service + Azure Database for PostgreSQL Flexible Server, and summarize when each is appropriate."_
 
-> **Expected:** Azure Copilot provides a recommended architecture, such as App Service + Azure SQL Database or App Service + Cosmos DB, with explanations for when each option is appropriate.
+> - Azure Copilot recommends a starter Azure web architecture such as App Service paired with Azure SQL Database, PostgreSQL, or Cosmos DB depending on workload needs.
+> - The response explains trade-offs such as relational vs. NoSQL data models, managed hosting, and operational simplicity.
+> - Copilot may also mention supporting services like Key Vault, Application Insights, Front Door, or networking controls.
+> - The answer is conceptual guidance, not an environment-specific deployment plan.
 
 ### Answer
 

--- a/03-Azure/01-03-Infrastructure/12_Azure_Copilot/walkthrough/solution-02.md
+++ b/03-Azure/01-03-Infrastructure/12_Azure_Copilot/walkthrough/solution-02.md
@@ -62,32 +62,34 @@ The plan aligns with the **Well-Architected Framework** pillars:
 
 ### Steps and Expected Responses
 
-**Prompt 1:** _"Can you add a Virtual Network with subnets for the App Service and the database?"_
+**Prompt 1:** _"In the Deployment Agent plan canvas for the Flask+PostgreSQL workload, add a Virtual Network `10.0.0.0/16` with an App Service subnet `10.0.1.0/24` and a database subnet `10.0.2.0/24` delegated to PostgreSQL Flexible Server."_
 
-> **Expected:** Azure Copilot updates the plan to include:
->
-> - A VNet (e.g., `10.0.0.0/16`)
-> - App Service subnet (e.g., `10.0.1.0/24`) with VNet integration
-> - Database subnet (e.g., `10.0.2.0/24`) with delegated subnet for PostgreSQL
+> - Azure Copilot returns an updated architecture narrative that includes a VNet and separate subnet roles for app and database connectivity.
+> - The response may mention VNet integration, subnet separation, private access patterns, or DNS considerations.
+> - A conceptual update is sufficient; Copilot does not need to produce deployed resources or exact CIDR blocks at this step.
+> - The important behavior is that Copilot revises the proposed design instead of asking the user to pick existing portal resources.
 
-**Prompt 2:** _"I want the PostgreSQL server to use private endpoints instead of public access."_
+**Prompt 2:** _"Revise the same NEW-workload design so PostgreSQL uses private access or private endpoints, and include the supporting DNS and networking considerations. Do not ask me to select existing resources."_
 
-> **Expected:** Azure Copilot adjusts the plan to:
->
-> - Disable public access on the PostgreSQL Flexible Server
-> - Add a Private Endpoint in the database subnet
-> - Configure a Private DNS Zone for `privatelink.postgres.database.azure.com`
+> - Azure Copilot updates the architecture to describe private database access patterns for PostgreSQL.
+> - The answer should mention supporting elements such as private DNS, VNet integration, or endpoint-related networking dependencies.
+> - Copilot may discuss the operational trade-off of stronger isolation versus higher complexity and cost.
+> - A design explanation is acceptable; the participant should not expect Copilot to open a resource picker for an existing private endpoint.
 
-**Prompt 3:** _"Add a Network Security Group to restrict traffic to the App Service subnet."_
+**Prompt 3:** _"Update the same NEW-workload design to include an NSG strategy for the application subnet. Describe the intended inbound and outbound restrictions rather than querying existing resources."_
 
-> **Expected:** Azure Copilot adds:
->
-> - An NSG with rules allowing only HTTP/HTTPS inbound
-> - Association of the NSG to the App Service subnet
+> - Azure Copilot explains an NSG approach that supports least-privilege traffic patterns around the application's network path.
+> - The response may clarify that App Service itself has special networking behavior and that subnet or adjacent-resource controls are part of the design story.
+> - Participants should expect guidance on rule intent and architecture impact, not necessarily a full numbered NSG rule set.
+> - The key success signal is a sensible security design update rather than a portal-side change.
 
-**Prompt 4:** _"What would be the estimated monthly cost for this setup at a basic tier?"_
+**Prompt 4:** _"Provide a rough monthly cost estimate for the planned infrastructure (App Service Basic, PostgreSQL Flexible Server Standard_B1ms in the Burstable tier, Key Vault Standard, Application Insights, VNet) assuming East US 2 list prices."_
 
-> **Expected:** Azure Copilot provides a cost estimate breakdown by resource. Note that these estimates are approximate and may vary.
+> - Copilot may respond in one of two ways:
+> - (a) Returns the SUBSCRIPTION spend forecast (historical/actual), not a plan estimate — this is the current Deployment Agent behavior
+> - (b) Returns a per-service estimate table for the planned SKUs at list price
+> - If you get (a), use the Azure Pricing Calculator for a plan-based estimate — link: https://azure.microsoft.com/pricing/calculator/
+> - Document the limitation; cost-for-plan in the Deployment Agent is an active roadmap item
 
 ### Answer
 
@@ -105,11 +107,11 @@ Before Terraform code is generated, you must explicitly approve the infrastructu
 2. **Click "I approve the plan"** to proceed to Terraform generation, **or** click **"Review the plan and make edits"** to return to the refinement conversation and request further changes
 3. Azure Copilot will **not** generate Terraform configurations until you approve the plan
 
-> **Note:** If you are iterating via prompts rather than buttons, you can also explicitly ask: _"Generate the Terraform configurations for this plan."_ — this serves as implicit approval.
+> **Note:** If you are iterating via prompts rather than buttons, you can also explicitly ask: _"Generate starter Terraform for a NEW Azure deployment of a Flask web app on App Service with PostgreSQL Flexible Server, Key Vault, and Application Insights. Include the main resources even if I still need to customize variables and networking details."_ — this serves as implicit approval.
 
 ### Steps
 
-1. **Approve the plan** by clicking **"I approve the plan"**, or enter the prompt: _"Generate the Terraform configurations for this plan."_
+1. **Approve the plan** by clicking **"I approve the plan"**, or enter the prompt: _"Generate starter Terraform for a NEW Azure deployment of a Flask web app on App Service with PostgreSQL Flexible Server, Key Vault, and Application Insights. Include the main resources even if I still need to customize variables and networking details."_
 2. **Wait for generation** — Azure Copilot will show a progress indicator
 3. **Click the maximize icon** on the artifact pane to see the full files
 4. Note that the artifact pane is **read-only** — you can review the generated files but cannot edit them directly. To make edits, export the files first using one of the deployment options in Task 4
@@ -246,19 +248,14 @@ For **production environments**, the GitHub Pull Request method is recommended b
 1. Start a **new conversation** (click the new chat icon)
 2. **Enable agent mode** again
 3. Enter the AKS prompt:
-   > _"Set up a multitenant SaaS application on AKS using Kubernetes namespaces for isolation, integrate Microsoft Entra for authentication, and centralize logs in Azure Log Analytics."_
+   > _"Design a NEW workload plan for a multitenant SaaS application on AKS using Kubernetes namespaces for tenant isolation, Microsoft Entra ID for authentication, and Azure Log Analytics for centralized logging. Do not select an existing cluster — this is a greenfield design."_
 
 ### Expected Plan Components
 
-| Component               | Azure Service                                | Purpose                   |
-| ----------------------- | -------------------------------------------- | ------------------------- |
-| Container Orchestration | Azure Kubernetes Service (AKS)               | Run the SaaS application  |
-| Tenant Isolation        | Kubernetes Namespaces + Network Policies     | Separate tenant workloads |
-| Identity                | Microsoft Entra ID                           | Authentication and RBAC   |
-| Logging                 | Log Analytics Workspace + Container Insights | Centralized monitoring    |
-| Networking              | Azure Virtual Network + Azure CNI            | AKS networking            |
-| DNS                     | Azure DNS Zone                               | Service discovery         |
-| Container Registry      | Azure Container Registry                     | Store container images    |
+- Azure Copilot proposes a new AKS-based SaaS architecture with tenant-isolation, identity, and logging components.
+- The answer should discuss trade-offs such as namespace isolation vs. stronger tenant isolation models, ingress, secrets, and observability.
+- A conceptual architecture summary is sufficient; the prompt should not require an existing AKS resource picker.
+- This step is successful if Copilot behaves like a solution architect for a new workload rather than a troubleshooter for an existing cluster.
 
 ### Answer
 

--- a/03-Azure/01-03-Infrastructure/12_Azure_Copilot/walkthrough/solution-03.md
+++ b/03-Azure/01-03-Infrastructure/12_Azure_Copilot/walkthrough/solution-03.md
@@ -129,9 +129,12 @@ Azure Copilot **correctly identifies the alert** from the portal context. The co
 
 ### Follow-Up Questions
 
-**Prompt:** _"Can you explain more about finding #1?"_
+**Prompt:** _"For the alert we just discussed (or for a typical App Insights alert if none exist), tell me what data you analyze, what findings you look for, and what remediation steps you would recommend."_
 
-> **Expected:** Azure Copilot expands on the specific finding with more detailed data, such as exact metric values, log entries, or dependency traces.
+> - Azure Copilot lists the major evidence sources it uses, such as metrics, traces, exceptions, dependency failures, and logs.
+> - The response explains how those signals map to likely causes like code regression, dependency failure, capacity pressure, or bad deployments.
+> - Copilot provides ordered remediation suggestions that are helpful even when no live alert data is available.
+> - Participants should expect workflow guidance and likely findings, not always a telemetry-rich postmortem.
 
 **Prompt:** _"What would happen if I don't address this issue?"_
 
@@ -191,7 +194,7 @@ Azure Monitor issues provide a **holistic view** across multiple alerts:
 ### Quick Investigation Workflow
 
 ```text
-Step 1: "What are the key alerts raised since the past 24 hours?"
+Step 1: "Summarize any Application Insights alerts raised in the past 24 hours. If none are present, say so clearly and tell me what traffic or failure signal I should generate for this lab."
          → Get a list of recent alerts
 
 Step 2: "Investigate alert [select from list or paste ID]"
@@ -212,7 +215,7 @@ Step 6: "Verify this alert hasn't recurred in the last hour"
 
 | Time               | Action                  | Copilot Prompt                                                      |
 | ------------------ | ----------------------- | ------------------------------------------------------------------- |
-| Start of shift     | Review overnight alerts | _"What are the key alerts raised since the past 24 hours?"_         |
+| Start of shift     | Review overnight alerts | _"Summarize any Application Insights alerts raised in the past 24 hours. If none are present, say so clearly and tell me what traffic or failure signal I should generate for this lab."_         |
 | Alert received     | Investigate immediately | _"Start an investigation for this alert"_                           |
 | Post-investigation | Document findings       | Copy the investigation summary to your incident management tool     |
 | After remediation  | Verify fix              | _"Have there been any new alerts for [resource] in the past hour?"_ |

--- a/03-Azure/01-03-Infrastructure/12_Azure_Copilot/walkthrough/solution-04.md
+++ b/03-Azure/01-03-Infrastructure/12_Azure_Copilot/walkthrough/solution-04.md
@@ -51,13 +51,12 @@ Top 5 Cost-Saving Opportunities for Subscription "Contoso Production"
 
 ### Broader Summary
 
-**Prompt:** _"Summarize total potential cost and carbon reduction from all active recommendations."_
+**Prompt:** _"Summarize total potential monthly savings from all active Azure Advisor cost recommendations, grouped by category (VM rightsizing, reserved instances, idle resources)."_
 
-> **Expected:** Azure Copilot aggregates all recommendations and shows:
->
-> - Total monthly/annual cost savings
-> - Carbon emission reduction estimates
-> - Breakdown by recommendation category (rightsizing, shutdown, reserved instances)
+> - Azure Copilot typically highlights the biggest areas to inspect first, such as oversized compute, idle resources, reservations, or storage lifecycle opportunities.
+> - The response may be based on spend patterns rather than explicit Azure Advisor items.
+> - A short prioritized list of savings themes is sufficient for this step.
+> - Treat the answer as triage guidance rather than a finalized optimization plan.
 
 ### Answer
 
@@ -75,6 +74,8 @@ The Optimization Agent identifies savings in categories like:
 ### Steps
 
 **Prompt 1:** _"Explain the recommendation for vm-copilot-oversized."_
+
+> 💡 **Multi-turn note:** Copilot may first ask a clarifying question such as _"Which time range should I analyze?"_. If so, reply with **"Use the last 30 days."** and Copilot will continue with the full recommendation.
 
 > **Expected response:**
 >
@@ -160,14 +161,12 @@ Azure Copilot generates a visual chart showing:
 
 ### Subscription Summary
 
-**Prompt:** _"Can you show me a breakdown of potential savings by resource type for my subscription?"_
+**Prompt:** _"Give me a subscription-level optimization summary: total potential monthly savings, breakdown by resource type (VMs, storage, databases), and the top 3 recommendations by impact."_
 
-> **Expected:** A chart or table breaking down savings by:
->
-> - VMs (rightsizing)
-> - VMSS (scaling)
-> - Shutdown recommendations
-> - Total potential savings
+> - Azure Copilot summarizes spend or optimization opportunities by service family such as compute, storage, or databases.
+> - The answer highlights likely savings themes and top cost drivers, even if it does not quantify every action precisely.
+> - A concise executive summary is enough; the response does not need to enumerate every recommendation in the subscription.
+> - Participants should use this as a briefing view before drilling into one specific optimization area.
 
 ### Answer
 
@@ -219,40 +218,12 @@ Visual charts are **highly valuable for stakeholder communication**:
 
 ### Azure CLI Script
 
-**Prompt:** _"Can you provide a CLI script to apply those optimizations?"_
+**Prompt:** _"Now generate the equivalent Azure CLI (bash) script to resize `vm-copilot-oversized` in `rg-copilot-<suffix>-ch03` from Standard_D4s_v3 to Standard_D2s_v3 (deallocate, resize, start)."_
 
-> **Expected response:**
->
-> ```bash
-> #!/bin/bash
-> # Resize VM: vm-copilot-oversized
-> # From: Standard_D4s_v3 → To: Standard_D2s_v3
->
-> RESOURCE_GROUP="rg-copilot-<suffix>-ch03"
-> VM_NAME="vm-copilot-oversized"
-> NEW_SIZE="Standard_D2s_v3"
->
-> # Step 1: Deallocate the VM
-> echo "Deallocating VM $VM_NAME..."
-> az vm deallocate \
->   --resource-group $RESOURCE_GROUP \
->   --name $VM_NAME
->
-> # Step 2: Resize the VM
-> echo "Resizing VM to $NEW_SIZE..."
-> az vm resize \
->   --resource-group $RESOURCE_GROUP \
->   --name $VM_NAME \
->   --size $NEW_SIZE
->
-> # Step 3: Start the VM
-> echo "Starting VM $VM_NAME..."
-> az vm start \
->   --resource-group $RESOURCE_GROUP \
->   --name $VM_NAME
->
-> echo "VM resized successfully to $NEW_SIZE"
-> ```
+> - Azure Copilot returns an Azure CLI template for deallocating, resizing, and restarting a VM.
+> - The response includes placeholders rather than assuming a live recommendation context was preserved.
+> - Copilot may also include subscription-selection or authentication commands at the top.
+> - Participants should expect a starter template that still needs final SKU and resource validation.
 
 ### Answer
 

--- a/03-Azure/01-03-Infrastructure/12_Azure_Copilot/walkthrough/solution-05.md
+++ b/03-Azure/01-03-Infrastructure/12_Azure_Copilot/walkthrough/solution-05.md
@@ -17,24 +17,17 @@
 
 **Prompt 1:** _"Which resources aren't zone-resilient?"_
 
-> **Expected response:**
->
-> ```text
-> Non-Zone-Resilient Resources in your environment:
->
-> 1. vm-copilot-noresilience (Virtual Machine)
->    Region: France Central (or your chosen deployment region)
->    Current: No availability zone configured
->    Risk: Single point of failure in one datacenter
->
-> 📊 Summary: 1 of 1 resources lack zone resiliency in rg-copilot-<suffix>-ch04
-> ```
->
-> **Note:** Your actual results will vary based on the resources in your subscription. The workshop VM `vm-copilot-noresilience` in `rg-copilot-<suffix>-ch04` is the key resource to focus on.
+> - Azure Copilot identifies candidate resources that appear not to use zone-resilient configurations, often using query-backed results.
+> - The response may be a short resource list rather than a fully summarized resiliency posture report.
+> - Sparse output is acceptable if the subscription contains only a few eligible resources.
+> - Participants should use the result as a starting inventory for follow-up questions rather than expecting a percentage-based score.
 
-**Prompt 2:** _"Which service groups are currently not zone-resilient?"_
+**Prompt 2:** _"Group any non-zone-resilient resources by service type and summarize the biggest resiliency gaps."_
 
-> **Expected:** A higher-level view grouping resources by service type and showing which service groups have gaps.
+> - Azure Copilot groups identified gaps by service or resource type rather than listing only individual resources.
+> - The summary highlights which service categories appear least resilient in the current environment.
+> - The answer may still be lightweight if there are few resources to analyze.
+> - This is sufficient for a management-style review of major resiliency gaps.
 
 **Prompt 3:** _"Is my VM vm-copilot-noresilience zone-resilient? If not, what steps are needed?"_
 
@@ -144,30 +137,23 @@ Automated scripts are available for **7 resource types**. For others, Azure Copi
 > ⚠️ These resources are at risk of data loss in a failure scenario.
 > ```
 
-**Prompt 2:** _"How many backup jobs failed in the last 24 hours?"_
+**Prompt 2:** _"In the last 24 hours, list any backup **job** failures in this subscription."_
 
-> **Expected:**
->
-> ```text
-> Backup Job Summary (Last 24 hours):
->
-> ✅ Successful: 15 jobs
-> ❌ Failed: 2 jobs
->   - vm-dev-server: VSS snapshot failed (Error: VMSnapshotProviderFailed)
->   - sqldb-reports: Connection timeout during backup
->
-> Recommendations:
-> 1. For vm-dev-server: Restart the VSS service and retry the backup
-> 2. For sqldb-reports: Check network connectivity and retry
-> ```
+> - Azure Copilot tells you whether recent backup-job failures are visible and may include vault, workload, or timing details.
+> - If no failures are found, a clear negative result is acceptable.
+> - The response may be brief and does not need to include a full root cause breakdown for each failed job.
+> - Use this as a quick operational check before deeper vault-specific investigation.
 
 **Prompt 3:** _"What are the key alerts raised since the past 24 hours?"_
 
 > **Expected:** A list of alerts with severity, resource, and brief description.
 
-**Prompt 4:** _"Which VMs don't have Azure Backup configured?"_
+**Prompt 4:** _"List virtual machines in this subscription that don't have an Azure Backup policy configured."_
 
-> **Expected:** A list of unprotected VMs with recommendations to enable backup.
+> - Azure Copilot identifies resources that appear to lack backup protection or recent recovery points, when that metadata is available.
+> - The result may be a candidate list rather than a full authoritative inventory of every protected and unprotected resource.
+> - Participants should expect to follow up on high-risk items rather than rely on a perfect one-shot compliance report.
+> - This still supports the learning objective of spotting backup gaps quickly.
 
 **Prompt 5:** _"How do I configure backup for my unprotected VMs?"_
 
@@ -192,9 +178,11 @@ These gaps directly impact business continuity — even one unprotected VM with 
 
 ## Task 4: Manage Backup Vaults
 
+> 💡 **Context tip:** prefix vault-management prompts with the subscription ID (e.g., `"Using subscription db467d04-…, …"`) so Copilot's skills have the scope they need without asking.
+
 ### Steps
 
-**Prompt 1:** _"Help me create a Recovery Services vault named rsv-copilot-workshop in my resource group rg-copilot-<suffix>-ch04."_
+**Prompt 1:** _"Using subscription `<your-subscription-id>`, help me create a Recovery Services vault named rsv-copilot-workshop in my resource group rg-copilot-<suffix>-ch04."_
 
 > **Expected:** Azure Copilot guides you through vault creation:
 >
@@ -202,29 +190,12 @@ These gaps directly impact business continuity — even one unprotected VM with 
 > 2. Creates the vault with default settings
 > 3. Confirms creation with vault details
 
-**Prompt 2:** _"Increase the security level of this vault."_
+**Prompt 2:** _"Outline a disaster recovery plan for the resources in rg-copilot-<suffix>-ch04: primary region, secondary region, RTO/RPO targets, and services needed (ASR, geo-backup, multi-region writes)."_
 
-> **Expected recommendations:**
->
-> ```text
-> Security Enhancements for rsv-copilot-workshop:
->
-> 1. ✅ Enable Soft Delete (14+ day retention for deleted backups)
->    Status: Enabled by default — verify it's not disabled
->
-> 2. ✅ Enable Multi-User Authorization (MUA)
->    Prevents any single admin from disabling security features
->    Requires: Azure Resource Guard setup
->
-> 3. ✅ Enable Immutable Vaults
->    Prevents backup data from being deleted before expiry
->
-> 4. ✅ Enable Cross-Region Restore
->    Allows restoration in the paired region during regional outages
->
-> 5. ✅ Configure Private Endpoints
->    Restricts vault access to your virtual network only
-> ```
+> - Azure Copilot outlines a disaster recovery planning approach covering backup, failover assumptions, and operational drills.
+> - The answer is usually general and process-oriented rather than tied to every deployed resource in the subscription.
+> - Participants should expect a planning checklist they can adapt into a real DR runbook.
+> - This step teaches DR thinking, not one-click DR automation.
 
 **Prompt 3:** _"How can I set up a backup policy for daily backups with 30-day retention?"_
 
@@ -280,27 +251,12 @@ These features are critical for **ransomware protection** and **compliance requi
 > Overall Score: ⚠️ Moderate Risk
 > ```
 
-**Prompt:** _"What are the top resiliency improvements I should make, prioritized by risk?"_
+**Prompt:** _"Generate a prioritized resiliency improvement plan for rg-copilot-<suffix>-ch04. Order the items by risk (Critical, High, Medium, Low), cover zone resiliency, backup coverage, vault security, and DR, and include one concrete action per item."_
 
-> **Expected prioritized plan:**
->
-> ```text
-> Priority 1 (Critical):
->   - Enable backup for unprotected VMs
->   - Configure zone resiliency for production VMs
->
-> Priority 2 (High):
->   - Enable vault security features (MUA, immutability)
->   - Configure Azure Site Recovery for critical workloads
->
-> Priority 3 (Medium):
->   - Enable zone redundancy for App Service and database
->   - Set up cross-region restore
->
-> Priority 4 (Low):
->   - Configure DR drills schedule
->   - Document recovery procedures
-> ```
+> - Azure Copilot returns a short prioritized list of resiliency improvements instead of a vague narrative.
+> - The actions are ordered by business risk and operational importance, even if some recommendations are based on best practices rather than deep telemetry.
+> - The answer should be suitable for sharing with management or auditors as a first-pass improvement plan.
+> - A concise prioritized output is more realistic than a comprehensive automatically generated strategy document.
 
 ### Answer
 

--- a/03-Azure/01-03-Infrastructure/12_Azure_Copilot/walkthrough/solution-06.md
+++ b/03-Azure/01-03-Infrastructure/12_Azure_Copilot/walkthrough/solution-06.md
@@ -74,7 +74,7 @@ The automatic diagnostic checks mirror what an experienced engineer would do man
 ### Steps
 
 1. **Start a new conversation** with agent mode enabled
-2. **Enter:** _"I'm trying to connect to my Azure Cosmos DB (NoSQL API) from my local development machine, but I keep getting a timeout. What should I do?"_
+2. **Enter:** _"I'm connecting to Azure Cosmos DB (NoSQL API) and getting connection failures. Give me a troubleshooting checklist covering firewall or IP allow-list, private endpoint/DNS, auth keys, TLS, and service health. If you need a resource, tell me what to select."_
 3. **Select the Cosmos DB account** if prompted, or work with guidance
 
 ### Expected Diagnostic Flow
@@ -147,37 +147,13 @@ Even when the agent can't directly access a resource (e.g., testing from your lo
 
 ### Steps
 
-**Prompt 1:** _"Investigate the health of my pods."_
+**Prompt 1:** _"Explain how you would diagnose an AKS cluster that is not scheduling pods. List the checks you would run (node status, taints, resource quotas, pending pods) and the kubectl commands required. No cluster needs to be deployed."_
 
-> **Expected response:**
->
-> ```text
-> 🔍 Pod Health Investigation for aks-contoso
->
-> Cluster Status: Running
-> Node Pool: agentpool (3 nodes)
->
-> Pod Status Summary:
-> ✅ Running: 12
-> ⚠️ Pending: 2
-> ❌ CrashLoopBackOff: 1
-> ❌ ImagePullBackOff: 1
->
-> Issues Found:
->
-> 1. Pod 'api-service-7d8f9' — CrashLoopBackOff
->    Container exits with code 1 after 3 seconds
->    Last log: "Error: Cannot connect to database at postgres:5432"
->    → Root Cause: Database connection string misconfigured
->    → Fix: Update the configmap or secret with correct DB connection details
->
-> 2. Pod 'frontend-abc12' — ImagePullBackOff
->    Image: contoso.azurecr.io/frontend:v2.1
->    Error: "unauthorized: authentication required"
->    → Root Cause: AKS doesn't have pull access to the ACR
->    → Fix: Attach ACR to AKS cluster using:
->       az aks update -n aks-contoso -g rg-copilot-<suffix>-ch05 --attach-acr contosoacr
-> ```
+> - Copilot returns a diagnostic playbook (no live execution)
+> - Checks: node status (`kubectl get nodes`), node conditions (`kubectl describe node`), pending pod events (`kubectl describe pod`), resource quotas (`kubectl get resourcequota`), taints/tolerations
+> - Common root causes: insufficient cluster capacity, node taints, PVC provisioning delay, resource quota exhaustion
+> - If a live cluster is selected, Copilot runs the checks directly and returns results
+> - Note: solution-06 Task 3 NOTE confirms no AKS cluster is deployed; this prompt is illustrative
 
 **Prompt 2:** _"Investigate networking issues causing pod connectivity failures."_
 
@@ -285,7 +261,7 @@ One-click fixes are available for **common, well-understood issues** with clear,
 
    Or with more context:
 
-   > _"My application is experiencing intermittent failures that I can't diagnose. Can you create a support request?"_
+   > _"Create a support request for a persistent VM boot issue on `vm-copilot-broken`. Include the symptoms, business impact, and the diagnostics I should attach before submitting."_
 
 2. **Azure Copilot gathers information:**
 

--- a/03-Azure/01-03-Infrastructure/12_Azure_Copilot/walkthrough/solution-07.md
+++ b/03-Azure/01-03-Infrastructure/12_Azure_Copilot/walkthrough/solution-07.md
@@ -15,21 +15,14 @@
 1. **Enable agent mode** in Azure Copilot
 2. **Enter the full workload description:**
 
-   > _"I need to deploy an e-commerce platform with the following components: a React frontend on App Service, a Node.js backend API on App Service, Azure Cosmos DB for the product catalog, Azure Cache for Redis for session management, Azure CDN for static assets, Application Insights for monitoring, and Azure Key Vault for secrets. All resources should be in East US 2 with a Virtual Network."_
+   > _"Using the Deployment Agent, plan a 3-tier web application in East US 2 that includes: App Service (Standard S1) for the frontend, Azure Cosmos DB (NoSQL API, serverless) for the product catalog, Azure Cache for Redis (Basic C0), Application Insights, Key Vault, and a Virtual Network with separate subnets for App, Data, and Cache tiers. After the plan is shown, open the plan canvas (look for a button such as View plan / Open plan canvas / View workload)."_
 
 ### Expected Infrastructure Plan
 
-| Component           | Azure Service                       | SKU/Tier                  | Purpose                      |
-| ------------------- | ----------------------------------- | ------------------------- | ---------------------------- |
-| Frontend            | App Service (Linux)                 | Standard S1               | Host React SPA               |
-| Backend API         | App Service (Linux)                 | Standard S2               | Host Node.js API             |
-| Database            | Azure Cosmos DB (NoSQL API)         | Serverless or Provisioned | Product catalog              |
-| Cache               | Azure Cache for Redis               | Standard C1               | Session management           |
-| CDN / Load Balancer | Azure Front Door (after refinement) | Standard                  | Global distribution + WAF    |
-| Monitoring          | Application Insights                | Per-GB                    | APM                          |
-| Secrets             | Azure Key Vault                     | Standard                  | Connection strings, API keys |
-| Networking          | Virtual Network                     | /16 address space         | Network isolation            |
-| Subnets             | 3 subnets                           | App, Data, Cache          | Segmentation                 |
+- Azure Copilot proposes a greenfield 3-tier architecture with the requested core services and supporting platform components.
+- The answer should call out security, networking, monitoring, and cost-conscious defaults at a high level.
+- Optional enhancements such as Key Vault, Front Door, Application Insights, or private networking may be suggested.
+- This phase is successful if participants get a coherent architecture blueprint rather than a deployed or fully optimized design package.
 
 ### Plan Approval
 


### PR DESCRIPTION
## Summary

Updates the Azure Copilot MicroHack content so challenge prompts, walkthrough expectations, and deployed resources better match observed Azure Copilot behavior in a real tenant.

## What changed

- Tightens challenge prompts across the specialized Azure Copilot agents so participants get more consistent results.
- Updates walkthrough expectations to account for realistic Copilot variability instead of relying on stale exact responses.
- Clarifies agent-mode usage, plan-canvas workflows, follow-up prompts, and no-cluster-required AKS troubleshooting guidance.
- Aligns Challenge 5/6 VM SKU references and cost notes with the deployed D-series VM sizes used for more deterministic agent scenarios.
- Keeps the PR scoped to `12_Azure_Copilot` content and IaC only.

## Validation

- Tested through live Azure Copilot E2E rounds in a real tenant.
- Re-reviewed with a focused MicroHack readiness audit before opening the PR.
- Checked the final branch is based on `upstream/main` with a single squashed commit.
