### PR TITLE
Rename secure migration Hack documentation

### DIFF
--- a/03-Azure/01-03-Infrastructure/06_Migration_Secure_AI_Ready/Readme.md
+++ b/03-Azure/01-03-Infrastructure/06_Migration_Secure_AI_Ready/Readme.md
@@ -4,13 +4,13 @@
 
 *From secure migration to agent-assisted cloud operations.*
 
-- [**Hack introduction**](#microhack-introduction)
-- [**Hack context**](#microhack-context)
+- [**Hack introduction**](#hack-introduction)
+- [**Hack context**](#hack-context)
 - [**Objectives**](#objectives)
-- [**Hack challenges**](#microhack-challenges)
+- [**Hack challenges**](#hack-challenges)
 - [**Contributors**](#contributors)
 
-<a id="microhack-introduction"></a>
+<a id="hack-introduction"></a>
 
 # Hack introduction
 
@@ -32,7 +32,7 @@ Optional follow-up reading:
 * [Azure Copilot Observability Agent](https://learn.microsoft.com/en-us/azure/azure-monitor/aiops/observability-agent-overview)
 * [Deploy files to Azure App Service](https://learn.microsoft.com/en-us/azure/app-service/deploy-zip)
 
-<a id="microhack-context"></a>
+<a id="hack-context"></a>
 
 # Hack context
 
@@ -66,7 +66,7 @@ After completing this Hack, you will be able to:
 * Inspect a selected IIS or Apache workload and manually replatform its static content to Windows App Service with ZIP deployment.
 * Explain why Azure Storage static website hosting or Azure Static Web Apps can be a better production target for a static workload.
 
-<a id="microhack-challenges"></a>
+<a id="hack-challenges"></a>
 
 # Hack challenges
 

--- a/03-Azure/01-03-Infrastructure/06_Migration_Secure_AI_Ready/Readme.md
+++ b/03-Azure/01-03-Infrastructure/06_Migration_Secure_AI_Ready/Readme.md
@@ -1,18 +1,20 @@
 ![image](img/1920x300_EventBanner_MicroHack_Migrate_wText.jpg)
 
-# MicroHack – Migrate and Secure to be ready for AI Ops
+# Migrate and Secure to be ready for AI Ops
 
 *From secure migration to agent-assisted cloud operations.*
 
-- [**MicroHack introduction**](#microhack-introduction)
-- [**MicroHack context**](#microhack-context)
+- [**Hack introduction**](#microhack-introduction)
+- [**Hack context**](#microhack-context)
 - [**Objectives**](#objectives)
-- [**MicroHack challenges**](#microhack-challenges)
+- [**Hack challenges**](#microhack-challenges)
 - [**Contributors**](#contributors)
 
-# MicroHack introduction
+<a id="microhack-introduction"></a>
 
-This MicroHack follows an end-to-end datacenter modernization journey. It combines Azure Migrate, security controls, Azure Monitor, intelligent operations, and a deliberate PaaS replatform. The scenario focuses on practical decisions, repeatable validation, cost awareness, and supported product capabilities.
+# Hack introduction
+
+This Hack follows an end-to-end datacenter modernization journey. It combines Azure Migrate, security controls, Azure Monitor, intelligent operations, and a deliberate PaaS replatform. The scenario focuses on practical decisions, repeatable validation, cost awareness, and supported product capabilities.
 
 This lab is not a complete migration-factory or application-modernization program. Use the following articles as foundational reading:
 
@@ -30,9 +32,11 @@ Optional follow-up reading:
 * [Azure Copilot Observability Agent](https://learn.microsoft.com/en-us/azure/azure-monitor/aiops/observability-agent-overview)
 * [Deploy files to Azure App Service](https://learn.microsoft.com/en-us/azure/app-service/deploy-zip)
 
-# MicroHack context
+<a id="microhack-context"></a>
 
-The MicroHack follows a coherent modernization storyline:
+# Hack context
+
+The Hack follows a coherent modernization storyline:
 
 1. **Discover** the Hyper-V-hosted servers and their inventory.
 2. **Assess** technical readiness and cloud sizing.
@@ -51,7 +55,7 @@ The Hyper-V discovery and migration design is described here:
 
 # Objectives
 
-After completing this MicroHack, you will be able to:
+After completing this Hack, you will be able to:
 
 * Build an assessment and business case for a datacenter transformation.
 * Plan and execute a right-sized Hyper-V VM migration to Azure.
@@ -62,7 +66,9 @@ After completing this MicroHack, you will be able to:
 * Inspect a selected IIS or Apache workload and manually replatform its static content to Windows App Service with ZIP deployment.
 * Explain why Azure Storage static website hosting or Azure Static Web Apps can be a better production target for a static workload.
 
-# MicroHack challenges
+<a id="microhack-challenges"></a>
+
+# Hack challenges
 
 ## General prerequisites
 
@@ -73,7 +79,7 @@ Complete these prerequisites before the session:
 * A Microsoft Entra user with Contributor or Owner permissions on the Azure subscription.
 * A client network and browser that support the Azure portal, Azure Bastion, and Azure Cloud Shell.
 
-Challenge 7 includes a preflight for Azure Copilot tenant access, RBAC, network access, and supported regions. Azure Copilot is not mandatory because the challenge includes a full KQL/VM insights fallback. No Azure OpenAI resource, model deployment, or model quota is required anywhere in this MicroHack.
+Challenge 7 includes a preflight for Azure Copilot tenant access, RBAC, network access, and supported regions. Azure Copilot is not mandatory because the challenge includes a full KQL/VM insights fallback. No Azure OpenAI resource, model deployment, or model quota is required anywhere in this Hack.
 
 ## Challenges
 

--- a/03-Azure/01-03-Infrastructure/06_Migration_Secure_AI_Ready/challenges/challenge-01.md
+++ b/03-Azure/01-03-Infrastructure/06_Migration_Secure_AI_Ready/challenges/challenge-01.md
@@ -3,7 +3,7 @@
 **[Home](../Readme.md)** - [Next Challenge](challenge-02.md)
 
 > [!IMPORTANT]
-> **Many of the resource deployments in this MicroHack are adapted from the [Jumpstart ArcBox for IT Pros](https://jumpstart.azure.com/azure_jumpstart_arcbox/ITPro). Special thanks to the [Jumpstart Team](https://aka.ms/arcjumpstart) for their excellent work.**
+> **Many of the resource deployments in this Hack are adapted from the [Jumpstart ArcBox for IT Pros](https://jumpstart.azure.com/azure_jumpstart_arcbox/ITPro). Special thanks to the [Jumpstart Team](https://aka.ms/arcjumpstart) for their excellent work.**
 
 ## Goal
 
@@ -12,11 +12,11 @@
 
 ## Actions
 
-- Deploy the [Bicep configuration](../resources) of the MicroHack.
+- Deploy the [Bicep configuration](../resources) for the Hack.
 
 ## Success criteria
 
-- You have understood the concept and architecture for the MicroHack.
+- You have understood the concept and architecture for the Hack.
 - The Bicep deployment command exits successfully.
 - The *source* and *destination* resource groups are visible in the Azure Portal.
 

--- a/03-Azure/01-03-Infrastructure/06_Migration_Secure_AI_Ready/challenges/challenge-07.md
+++ b/03-Azure/01-03-Infrastructure/06_Migration_Secure_AI_Ready/challenges/challenge-07.md
@@ -44,7 +44,7 @@ At the start of this challenge, select one track. Follow the same VM and track t
 * Create or reuse an action group and create an actionable log search alert.
 * Use Azure Copilot Observability Agent chat, or the KQL/VM insights fallback, to distinguish a service outage from a VM outage.
 * Restore the selected service and verify local, external, and telemetry recovery.
-* Decide which lab monitoring resources should remain after the MicroHack.
+* Decide which lab monitoring resources should remain after the Hack.
 
 ### Track A - Windows Server / IIS
 

--- a/03-Azure/01-03-Infrastructure/06_Migration_Secure_AI_Ready/challenges/challenge-08.md
+++ b/03-Azure/01-03-Infrastructure/06_Migration_Secure_AI_Ready/challenges/challenge-08.md
@@ -16,7 +16,7 @@ Continue with the same track:
 Teams complete only their selected track.
 
 > [!IMPORTANT]
-> Azure Migrate's agentless at-scale web-app migration supports ASP.NET applications on Windows IIS servers hosted in VMware environments. It does not support direct web-app migration from this MicroHack's Hyper-V source scenario or this Linux/Apache workload. This challenge therefore performs a deliberate manual replatform from the already migrated Azure VM.
+> Azure Migrate's agentless at-scale web-app migration supports ASP.NET applications on Windows IIS servers hosted in VMware environments. It does not support direct web-app migration from this Hack's Hyper-V source scenario or this Linux/Apache workload. This challenge therefore performs a deliberate manual replatform from the already migrated Azure VM.
 
 ## Prerequisites
 

--- a/03-Azure/01-03-Infrastructure/06_Migration_Secure_AI_Ready/challenges/finish.md
+++ b/03-Azure/01-03-Infrastructure/06_Migration_Secure_AI_Ready/challenges/finish.md
@@ -1,10 +1,10 @@
-# MicroHack – Migrate and Secure to be ready for AI Ops
+# Migrate and Secure to be ready for AI Ops
 
 [Previous Challenge](challenge-08.md) - **[Home](../Readme.md)**
 
 ## Congratulations
 
-You finished *MicroHack – Migrate and Secure to be ready for AI Ops*.
+You finished *Migrate and Secure to be ready for AI Ops*.
 
 *From secure migration to agent-assisted cloud operations.*
 

--- a/03-Azure/01-03-Infrastructure/06_Migration_Secure_AI_Ready/resources/README.md
+++ b/03-Azure/01-03-Infrastructure/06_Migration_Secure_AI_Ready/resources/README.md
@@ -1,4 +1,4 @@
-# Deploy the Landing Zone for the MicroHack
+# Deploy the Landing Zone for the Hack
 
 Download the \*.bicep files to your local PC and follow [Solution 1](../walkthrough/challenge-01/solution-01.md).
 

--- a/03-Azure/01-03-Infrastructure/06_Migration_Secure_AI_Ready/walkthrough/challenge-01/solution-01.md
+++ b/03-Azure/01-03-Infrastructure/06_Migration_Secure_AI_Ready/walkthrough/challenge-01/solution-01.md
@@ -7,13 +7,13 @@ Duration: 30 minutes
 ## Prerequisites
 
 - Please ensure that you successfully verified the [General prerequisites](../../Readme.md#general-prerequisites) before continuing with this challenge.
-- The Azure CLI is required to deploy the Bicep configuration of the MicroHack.
+- The Azure CLI is required to deploy the Bicep configuration for the Hack.
 - Clone the GitHub repository or download the [Resources](../../resources) directory to your local PC.
 
 > [!IMPORTANT]
-> **Many of the resource deployments in this MicroHack are adapted from the [Jumpstart ArcBox for IT Pros](https://jumpstart.azure.com/azure_jumpstart_arcbox/ITPro). Special thanks to the [Jumpstart Team](https://aka.ms/arcjumpstart) for their excellent work.**
+> **Many of the resource deployments in this Hack are adapted from the [Jumpstart ArcBox for IT Pros](https://jumpstart.azure.com/azure_jumpstart_arcbox/ITPro). Special thanks to the [Jumpstart Team](https://aka.ms/arcjumpstart) for their excellent work.**
 
-### **Task 1: Deploy the Landing Zone for the MicroHack**
+### **Task 1: Deploy the Landing Zone for the Hack**
 
 - Open the [Azure Portal](https://portal.azure.com) and log in using a user account with at least Contributor permissions on an Azure subscription. Start Azure Cloud Shell from the menu bar at the top.
 
@@ -32,7 +32,7 @@ Duration: 30 minutes
 
 ![image](./img/CS3.png)
 
-- Clone the MicroHack GitHub repository using the following command:
+- Clone the Hack GitHub repository using the following command:
 
 ```bash
 git clone https://github.com/microsoft/MicroHack.git
@@ -40,7 +40,7 @@ git clone https://github.com/microsoft/MicroHack.git
 
 ![image](./img/CS4.png)
 
-- Change into the desired MicroHack directory of the cloned repository using the command:
+- Change into the Hack's resources directory in the cloned repository using the command:
 
 ```bash 
 cd MicroHack/03-Azure/01-03-Infrastructure/06_Migration_Secure_AI_Ready/resources/bicep

--- a/03-Azure/01-03-Infrastructure/06_Migration_Secure_AI_Ready/walkthrough/challenge-02/solution-02.md
+++ b/03-Azure/01-03-Infrastructure/06_Migration_Secure_AI_Ready/walkthrough/challenge-02/solution-02.md
@@ -32,7 +32,7 @@ Your previously created Azure Migrate project should be listed. Click on it to o
 
 ### **Task 2: Install the Azure Migrate appliance for Hyper-V discovery**
 
-Hyper-V discovery uses an Azure Migrate appliance that connects to the Hyper-V host and continuously collects VM configuration, performance metadata, and workload inventory. For this MicroHack, install and register the appliance by running the PowerShell installation script on the existing **MHBOX-AzMigSrv** server, and then connect it to **MHBox-HV**.
+Hyper-V discovery uses an Azure Migrate appliance that connects to the Hyper-V host and continuously collects VM configuration, performance metadata, and workload inventory. For this Hack, install and register the appliance by running the PowerShell installation script on the existing **MHBOX-AzMigSrv** server, and then connect it to **MHBox-HV**.
 
 > [!IMPORTANT]
 > Check the current [Hyper-V discovery prerequisites](https://learn.microsoft.com/en-us/azure/migrate/tutorial-discover-hyper-v?view=migrate#prerequisites) for the Azure Migrate appliance and Hyper-V host.

--- a/03-Azure/01-03-Infrastructure/06_Migration_Secure_AI_Ready/walkthrough/challenge-04/solution-04.md
+++ b/03-Azure/01-03-Infrastructure/06_Migration_Secure_AI_Ready/walkthrough/challenge-04/solution-04.md
@@ -76,7 +76,7 @@ Agentless dependency analysis works by capturing TCP connection data from server
 
 For agent-based analysis, Azure Migrate: Discovery and assessment uses the Service Map solution in Azure Monitor. You install the Microsoft Monitoring Agent/Log Analytics agent and the Dependency agent on each server you want to analyze.
 
-In this MicroHack, we will use agentless dependency analysis.
+In this Hack, we will use agentless dependency analysis.
 
 > [!NOTE]
 > Agentless dependency analysis is automatically enabled for the discovered servers when the prerequisite checks are successful. Unlike before, you no longer need to manually enable this feature on servers.

--- a/03-Azure/01-03-Infrastructure/06_Migration_Secure_AI_Ready/walkthrough/challenge-05/solution-05.md
+++ b/03-Azure/01-03-Infrastructure/06_Migration_Secure_AI_Ready/walkthrough/challenge-05/solution-05.md
@@ -152,7 +152,7 @@ Connect to each test VM via Azure Bastion.
 
 ![image](./img/TestMig5.png)
 
-On the Windows VM, open a browser and navigate to *http://localhost*. On the Ubuntu VM, run `curl -I http://localhost`. Confirm that the MicroHack Demo Web App responds successfully on both test VMs.
+On the Windows VM, open a browser and navigate to *http://localhost*. On the Ubuntu VM, run `curl -I http://localhost`. Confirm that the Hack Demo Web App responds successfully on both test VMs.
 
 ![image](./img/TestMig6.png)
 

--- a/03-Azure/01-03-Infrastructure/06_Migration_Secure_AI_Ready/walkthrough/challenge-06/solution-06.md
+++ b/03-Azure/01-03-Infrastructure/06_Migration_Secure_AI_Ready/walkthrough/challenge-06/solution-06.md
@@ -74,7 +74,7 @@ Next, verify that the alert was forwarded to Azure. Open the portal, select *Def
 
 ## **Task 4: Explore *Defender for Cloud* proactive security advice**
 
-The challenges in this MicroHack were designed to be simple, with virtual machines deployed in a single subscription. For simplicity, the lab omits the secure, scalable landing zone recommended by the *Cloud Adoption Framework* ([What is an Azure landing zone? - Cloud Adoption Framework | Microsoft Learn](https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/)).
+The challenges in this Hack were designed to be simple, with virtual machines deployed in a single subscription. For simplicity, the lab omits the secure, scalable landing zone recommended by the *Cloud Adoption Framework* ([What is an Azure landing zone? - Cloud Adoption Framework | Microsoft Learn](https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/)).
 
 As a result, *Defender for Cloud* makes several recommendations for proactively improving the security of the environment.
 To view general security recommendations for the managed virtual machines, please open the portal and select Defender for Cloud. Under Security Posture, you can view the recommendations in detail.
@@ -91,7 +91,7 @@ Go back to *Defender for Cloud* and click *Attack path analysis*. This view prov
 
 ![image](./img/secpost03.png)
 
-In this MicroHack, we deployed virtual machines that use public IP addresses and are directly exposed to the internet. This approach is straightforward but isn't a best practice. Click one of the *Attack paths* to learn more about the attack vector.
+In this Hack, we deployed virtual machines that use public IP addresses and are directly exposed to the internet. This approach is straightforward but isn't a best practice. Click one of the *Attack paths* to learn more about the attack vector.
 
 ![image](./img/secpost04.png)
 

--- a/03-Azure/01-03-Infrastructure/06_Migration_Secure_AI_Ready/walkthrough/challenge-07/solution-07.md
+++ b/03-Azure/01-03-Infrastructure/06_Migration_Secure_AI_Ready/walkthrough/challenge-07/solution-07.md
@@ -43,7 +43,7 @@ The service must be `active` and HTTP must return `200`.
 1. In the portal, select **Copilot**. If an unauthorized message appears, ask a tenant administrator to follow [Manage access to Azure Copilot](https://learn.microsoft.com/en-us/azure/copilot/manage-access). In a restricted tenant, the user or a group containing the user needs the **Copilot for Azure User** role.
 2. Confirm the client network allows WebSocket connections to `https://directline.botframework.com`.
 3. Open the [Observability Agent overview](https://learn.microsoft.com/en-us/azure/azure-monitor/aiops/observability-agent-overview#regions) and confirm that the intended Log Analytics workspace region is supported.
-4. Confirm your signed-in account can read the VM and its monitoring data and create the required monitoring resources. The MicroHack's Contributor or Owner prerequisite is sufficient. For least privilege, review **Monitoring Reader**, **Log Analytics Reader**, and the specific write roles required for DCRs and alerts.
+4. Confirm your signed-in account can read the VM and its monitoring data and create the required monitoring resources. The Contributor or Owner prerequisite for this Hack is sufficient. For least privilege, review **Monitoring Reader**, **Log Analytics Reader**, and the specific write roles required for DCRs and alerts.
 
 > [!IMPORTANT]
 > If Azure Copilot, the **Observability Agent** button, the selected region, or tenant access is unavailable, continue with Tasks 2 through 4 and use the fallback in Task 5. Do not provision an Azure OpenAI resource or model. Do not create an Observability Agent resource for the required path.
@@ -442,7 +442,7 @@ For either track, test the existing external endpoint. If automatic alert resolu
 
 ### Cleanup
 
-Keep VM monitoring for Challenge 8 unless your instructor asks you to remove it. After the MicroHack, you may independently remove the alert rule, action group, selected event DCR association/DCR, and Log Analytics workspace if they were created only for this lab. Do not delete shared resources.
+Keep VM monitoring for Challenge 8 unless your instructor asks you to remove it. After the Hack, you may independently remove the alert rule, action group, selected event DCR association/DCR, and Log Analytics workspace if they were created only for this lab. Do not delete shared resources.
 
 ### Optional stretch - autonomous operations (preview)
 

--- a/03-Azure/01-03-Infrastructure/06_Migration_Secure_AI_Ready/walkthrough/challenge-08/solution-08.md
+++ b/03-Azure/01-03-Infrastructure/06_Migration_Secure_AI_Ready/walkthrough/challenge-08/solution-08.md
@@ -13,7 +13,7 @@ Complete only your selected track.
 
 ## Task 1: Discover the web application before choosing a target (10 minutes)
 
-Azure Migrate's at-scale web-app migration flow supports ASP.NET web apps on Windows IIS servers hosted in VMware environments. This MicroHack uses Hyper-V, and the integrated flow doesn't support the Linux/Apache workload. We will deliberately inspect and manually replatform the selected migrated workload.
+Azure Migrate's at-scale web-app migration flow supports ASP.NET web apps on Windows IIS servers hosted in VMware environments. This Hack uses Hyper-V, and the integrated flow doesn't support the Linux/Apache workload. We will deliberately inspect and manually replatform the selected migrated workload.
 
 ### Track A - Inventory Windows/IIS
 
@@ -458,4 +458,4 @@ az account clear
 
 Interactive sign-in is appropriate for this guided lab. Signing out and clearing the local subscription cache reduce credential exposure on the VM. No publishing credentials were used or exposed.
 
-You successfully completed Challenge 8 and the MicroHack.
+You successfully completed Challenge 8 and the Hack.


### PR DESCRIPTION
## Summary

- Rename the secure migration Hack title to `Migrate and Secure to be ready for AI Ops`.
- Update user-visible Markdown terminology from `MicroHack` to `Hack`.
- Rename README anchors and table-of-contents fragments from `microhack-*` to `hack-*`.

## Scope

Technical paths, repository URLs, commands, filenames, variables, Syslog identifiers, ZIP package identifiers, scripts, and non-Markdown assets are intentionally unchanged.

## Validation

- Verified local Markdown links, images, fragments, and navigation.
- Verified balanced Markdown fences.
- Confirmed code blocks, inline code, link destinations, and URLs are unchanged.
- Ran `git diff --check`.