### PR TITLE
Remove the dry-run step from App Modernization Challenge 1

### DIFF
--- a/03-Azure/01-01-App Innovation/03_GHCPAppModernization/challenges/challenge-01.md
+++ b/03-Azure/01-01-App Innovation/03_GHCPAppModernization/challenges/challenge-01.md
@@ -22,7 +22,6 @@ Before pointing AI at a real .NET or Java application (challenges 2 and 3), you 
 * **Author a Custom Agent** — copy [templates/agents/modernization.agent.md](../templates/agents/modernization.agent.md) to `.github/agents/<name>.agent.md` in a target repo, replace every `{{PLACEHOLDER}}`, and tighten the tool allow-list so the assessment phase stays read-only (least privilege).
 * **Author a Skill** — copy [templates/skills/modernization-skill/SKILL.md](../templates/skills/modernization-skill/SKILL.md) to `.github/skills/<skill-name>/SKILL.md`, and write an explicit `WHEN:` trigger description plus at least one transformation-rules table. Optionally use the [skill-creator](../templates/skills/skill-creator/SKILL.md) meta-skill to iterate.
 * **Configure MCP** — copy [templates/mcp/mcp.json](../templates/mcp/mcp.json) to `.vscode/mcp.json`, then run **MCP: List Servers** and confirm the `appmod-*` tools (registered by the App Modernization extensions) appear in the agent's tool picker.
-* **Dry-run the loop** — select your Custom Agent in Copilot Chat and prompt it to modernize a sample. Confirm it **stops at Gate 1 (assessment)** and **Gate 2 (plan)** before editing any code.
 * Compare your work against the pre-tailored references shipped in [templates/](../templates/) (`dotnet-modernization.agent.md`, `dotnet-upgrade`, `java-modernization.agent.md`, `java-upgrade`).
 
 ## Success criteria
@@ -31,7 +30,6 @@ Before pointing AI at a real .NET or Java application (challenges 2 and 3), you 
 * A valid Custom Agent (`.agent.md` with YAML frontmatter) exists, with a phased, gated workflow and a least-privilege tool list.
 * A valid Skill (`SKILL.md`) exists with an explicit `WHEN:` trigger description and at least one rules table.
 * `.vscode/mcp.json` is configured and **MCP: List Servers** resolves the servers; the `appmod-*` tools are visible to the agent.
-* When run, the agent respects the gates — it does **not** modify code before the assessment and plan are approved.
 
 > Need the detailed, step-by-step walkthrough? See the [Challenge 1 Solution](../walkthrough/challenge-01/solution-01.md).
 

--- a/03-Azure/01-01-App Innovation/03_GHCPAppModernization/walkthrough/challenge-01/solution-01.md
+++ b/03-Azure/01-01-App Innovation/03_GHCPAppModernization/walkthrough/challenge-01/solution-01.md
@@ -44,20 +44,12 @@ Author a reusable, gated modernization Custom Agent, package a Skill, and config
 3. Open the Command Palette → **MCP: List Servers** and start/inspect the servers.
 4. Confirm the `appmod-*` tool families appear in the agent's tool picker — they are registered automatically by the GitHub Copilot app modernization extensions (install the extension for your stack; no `mcp.json` entry needed).
 
-### Dry-run the gated loop
-
-1. Select your Custom Agent in Copilot Chat.
-2. Prompt: *"Modernize this application following your workflow."*
-3. Verify the agent runs the assessment and **stops at Gate 1** with an `ASSESSMENT.md`, then **stops at Gate 2** with a `PLAN.md` — without editing any source code.
-4. Approve to continue, or reject the plan once on purpose and watch the agent revise it.
-
 ## Success Criteria
 
 - ✅ You can explain Agent vs Skill vs MCP in one sentence each
 - ✅ A valid `.agent.md` exists with a gated, phased workflow and a least-privilege tool list
 - ✅ A valid `SKILL.md` exists with an explicit `WHEN:` trigger description and a rules table
 - ✅ `.vscode/mcp.json` resolves via **MCP: List Servers**; `appmod-*` tools are visible to the agent
-- ✅ The agent respects Gate 1 and Gate 2 and does not modify code before approval
 
 ## Learning Resources
 


### PR DESCRIPTION
## Problem

In `03-Azure/01-01-App Innovation/03_GHCPAppModernization`, Challenge 1 ends with:

> **Dry-run the loop** — select your Custom Agent in Copilot Chat and prompt it to modernize a sample. Confirm it **stops at Gate 1 (assessment)** and **Gate 2 (plan)** before editing any code.

No application is available at that point. The `PhotoAlbum` and `PhotoAlbum-Java` samples are only forked in Challenge 2, so participants have nothing to run the agent against and the step cannot be completed as written.

## Changes

- Remove the **Dry-run the loop** action from `challenge-01.md`, along with the matching success criterion (*"When run, the agent respects the gates…"*).
- Remove the corresponding **Dry-run the gated loop** section and success criterion from `walkthrough/challenge-01/solution-01.md`.

Challenge 1 now stops at authoring and configuring the agent, skill, and MCP files — all of which are verifiable without a sample application. Challenge 2 is unchanged.