### PR TITLE
added shared deployment costs

### DIFF
--- a/99-MicroHack-Template/labautomation/README.md
+++ b/99-MicroHack-Template/labautomation/README.md
@@ -163,25 +163,25 @@ Only include fields you want to set; missing fields fall back to platform defaul
 
 The number of Azure subscriptions required for a deployment is:
 
-$$
-  ext{subs} =
+```math
+\displaystyle \text{subs} =
 \begin{cases}
-  ext{units} & \text{deploymentType} = \texttt{subscription} \\[4pt]
+\displaystyle \text{units} & \text{deploymentType} = \texttt{subscription} \\[4pt]
 \left\lceil \dfrac{\text{units}}{\text{labsPerSubscription}} \right\rceil
 & \text{deploymentType} \in \{\texttt{resourcegroup}, \texttt{resourcegroup-with-subscriptionowner}\}
 \end{cases}
-$$
+```
 
 The final estimated cost in USD is:
 
-$$
-  ext{est} = \text{days} \times \left(
-  ext{units} \times
+```math
+\displaystyle \text{est} = \text{days} \times \left(
+\displaystyle \text{units} \times
 \underbrace{\left(\text{estimatedDailyCostsUsd} + \textstyle\sum \text{groupSurcharge}\right)}_{\text{per-lab}}
 + \text{subs} \times
 \underbrace{\text{estimatedSharedDeploymentDailyCostsUsd}}_{\text{per-subscription}}
 \right)
-$$
+```
 
 Here, `units` is the number of lab environments, `days` is the deployment duration,
 and $\sum \text{groupSurcharge}$ represents the license costs for `groups` per lab.

--- a/99-MicroHack-Template/labautomation/README.md
+++ b/99-MicroHack-Template/labautomation/README.md
@@ -166,8 +166,8 @@ The number of Azure subscriptions required for a deployment is:
 ```math
 \displaystyle \text{subs} =
 \begin{cases}
-\displaystyle \text{units} & \text{deploymentType} = \texttt{subscription} \\[4pt]
-\left\lceil \dfrac{\text{units}}{\text{labsPerSubscription}} \right\rceil
+\displaystyle \text{labs} & \text{deploymentType} = \texttt{subscription} \\[4pt]
+\left\lceil \dfrac{\text{labs}}{\text{labsPerSubscription}} \right\rceil
 & \text{deploymentType} \in \{\texttt{resourcegroup}, \texttt{resourcegroup-with-subscriptionowner}\}
 \end{cases}
 ```
@@ -176,16 +176,16 @@ The final estimated cost in USD is:
 
 ```math
 \displaystyle \text{est} = \text{days} \times \left(
-\displaystyle \text{units} \times
+\displaystyle \text{labs} \times
 \underbrace{\left(\text{estimatedDailyCostsUsd} + \textstyle\sum \text{groupSurcharge}\right)}_{\text{per-lab}}
 + \text{subs} \times
 \underbrace{\text{estimatedSharedDeploymentDailyCostsUsd}}_{\text{per-subscription}}
 \right)
 ```
 
-Here, `units` is the number of lab environments, `days` is the deployment duration,
+Here, `labs` is the number of lab environments, `days` is the deployment duration,
 and $\sum \text{groupSurcharge}$ represents the license costs for `groups` per lab.
-Per-lab costs and group surcharges are multiplied by `units`; shared deployment costs are multiplied by `subs`
+Per-lab costs and group surcharges are multiplied by `labs`; shared deployment costs are multiplied by `subs`
 because `shared-deploy-lab.ps1` runs once per subscription.
 
 ### `groups`: supported values

--- a/99-MicroHack-Template/labautomation/README.md
+++ b/99-MicroHack-Template/labautomation/README.md
@@ -164,9 +164,9 @@ Only include fields you want to set; missing fields fall back to platform defaul
 The number of Azure subscriptions required for a deployment is:
 
 $$
-	ext{subs} =
+  ext{subs} =
 \begin{cases}
-	ext{units} & \text{deploymentType} = \texttt{subscription} \\[4pt]
+  ext{units} & \text{deploymentType} = \texttt{subscription} \\[4pt]
 \left\lceil \dfrac{\text{units}}{\text{labsPerSubscription}} \right\rceil
 & \text{deploymentType} \in \{\texttt{resourcegroup}, \texttt{resourcegroup-with-subscriptionowner}\}
 \end{cases}
@@ -175,8 +175,8 @@ $$
 The final estimated cost in USD is:
 
 $$
-	ext{est} = \text{days} \times \left(
-	ext{units} \times
+  ext{est} = \text{days} \times \left(
+  ext{units} \times
 \underbrace{\left(\text{estimatedDailyCostsUsd} + \textstyle\sum \text{groupSurcharge}\right)}_{\text{per-lab}}
 + \text{subs} \times
 \underbrace{\text{estimatedSharedDeploymentDailyCostsUsd}}_{\text{per-subscription}}

--- a/99-MicroHack-Template/labautomation/README.md
+++ b/99-MicroHack-Template/labautomation/README.md
@@ -141,7 +141,8 @@ and is validated when your MicroHack is loaded.
   "deploymentType": "resourcegroup",
   "labsPerSubscription": 4,
   "preferredLocation": "swedencentral, norwayeast, spaincentral",
-  "estimatedDailyCostsUsd": 25.0
+  "estimatedDailyCostsUsd": 25.0,
+  "estimatedSharedDeploymentDailyCostsUsd": 0.0
 }
 ```
 
@@ -156,6 +157,36 @@ Only include fields you want to set; missing fields fall back to platform defaul
 | `labsPerSubscription` | `integer` (1–100) | How many users to pack into a single Azure subscription. Ignored when `deploymentType` is `subscription`. |
 | `preferredLocation` | `string` | Comma-separated Azure regions, **in priority order** (e.g. `"swedencentral, norwayeast"`). The first region is used as the default deployment location. List multiple regions so your script can fall back if the first region doesn't support every service your lab needs; see [authoring guidelines](#authoring-guidelines). |
 | `estimatedDailyCostsUsd` | `number` (≥ 0) | Estimated daily cost per lab environment in USD. Used for cost forecasting in the lab lifecycle wizard. |
+| `estimatedSharedDeploymentDailyCostsUsd` | `number` (≥ 0) | Estimated daily cost in USD of resources created once per subscription by `shared-deploy-lab.ps1`. Cost forecasting multiplies this value by the subscription count: labs divided by `labsPerSubscription`, rounded up, for resource-group deployments; one subscription per lab for `subscription` deployments. Defaults to `0` when absent. |
+
+### Cost forecasting formula
+
+The number of Azure subscriptions required for a deployment is:
+
+$$
+	ext{subs} =
+\begin{cases}
+	ext{units} & \text{deploymentType} = \texttt{subscription} \\[4pt]
+\left\lceil \dfrac{\text{units}}{\text{labsPerSubscription}} \right\rceil
+& \text{deploymentType} \in \{\texttt{resourcegroup}, \texttt{resourcegroup-with-subscriptionowner}\}
+\end{cases}
+$$
+
+The final estimated cost in USD is:
+
+$$
+	ext{est} = \text{days} \times \left(
+	ext{units} \times
+\underbrace{\left(\text{estimatedDailyCostsUsd} + \textstyle\sum \text{groupSurcharge}\right)}_{\text{per-lab}}
++ \text{subs} \times
+\underbrace{\text{estimatedSharedDeploymentDailyCostsUsd}}_{\text{per-subscription}}
+\right)
+$$
+
+Here, `units` is the number of lab environments, `days` is the deployment duration,
+and $\sum \text{groupSurcharge}$ represents the license costs for `groups` per lab.
+Per-lab costs and group surcharges are multiplied by `units`; shared deployment costs are multiplied by `subs`
+because `shared-deploy-lab.ps1` runs once per subscription.
 
 ### `groups`: supported values
 

--- a/99-MicroHack-Template/labautomation/lab-defaults.json
+++ b/99-MicroHack-Template/labautomation/lab-defaults.json
@@ -4,5 +4,6 @@
   "deploymentType": "resourcegroup",
   "labsPerSubscription": 4,
   "preferredLocation": "swedencentral, norwayeast, spaincentral",
-  "estimatedDailyCostsUsd": 25.0
+  "estimatedDailyCostsUsd": 25.0,
+  "estimatedSharedDeploymentDailyCostsUsd": 0.0
 }

--- a/lab-defaults-schema.json
+++ b/lab-defaults-schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Lab Defaults",
-  "description": "Smart defaults for the lab lifecycle wizard. Only include fields you want to override — missing fields are ignored.",
+  "description": "Smart defaults for the lab lifecycle wizard. Place as lab-defaults.json in hackcontent/<slug>/lab/. Only include fields you want to override — missing fields are ignored.",
   "type": "object",
   "properties": {
     "groups": {
@@ -27,7 +27,12 @@
     "estimatedDailyCostsUsd": {
       "type": "number",
       "minimum": 0,
-      "description": "Estimated daily cost per lab environment in USD. Used for cost forecasting in the lab lifecycle wizard."
+      "description": "Estimated daily cost per lab environment in USD: the running cost of the resources deploy-lab.ps1 creates. Used for cost forecasting in the lab lifecycle wizard. Defaults to 25 when absent or < 1."
+    },
+    "estimatedSharedDeploymentDailyCostsUsd": {
+      "type": "number",
+      "minimum": 0,
+      "description": "Estimated daily cost in USD of the resources shared-deploy-lab.ps1 creates. That hook runs once per Azure subscription, so this is multiplied by the subscription count: labs / labsPerSubscription (rounded up) for deploymentType resourcegroup and resourcegroup-with-subscriptionowner, or one per lab for deploymentType subscription. Defaults to 0 when absent or negative."
     }
   },
   "additionalProperties": false


### PR DESCRIPTION

The number of Azure subscriptions required for a deployment is:

$$
	ext{subs} =
\begin{cases}
	ext{units} & \text{deploymentType} = \texttt{subscription} \\[4pt]
\left\lceil \dfrac{\text{units}}{\text{labsPerSubscription}} \right\rceil
& \text{deploymentType} \in \{\texttt{resourcegroup}, \texttt{resourcegroup-with-subscriptionowner}\}
\end{cases}
$$

The final estimated cost in USD is:

$$
	ext{est} = \text{days} \times \left(
	ext{units} \times
\underbrace{\left(\text{estimatedDailyCostsUsd} + \textstyle\sum \text{groupSurcharge}\right)}_{\text{per-lab}}
+ \text{subs} \times
\underbrace{\text{estimatedSharedDeploymentDailyCostsUsd}}_{\text{per-subscription}}
\right)
$$

Here, `units` is the number of lab environments, `days` is the deployment duration,
and $\sum \text{groupSurcharge}$ represents the license costs for `groups` per lab.
Per-lab costs and group surcharges are multiplied by `units`; shared deployment costs are multiplied by `subs`
because `shared-deploy-lab.ps1` runs once per subscription.
