### PR TITLE
Review of challenge-03

### DIFF
--- a/03-Azure/01-04-AI/07_Fraud_Intelligence/challenges/challenge-03.md
+++ b/03-Azure/01-04-AI/07_Fraud_Intelligence/challenges/challenge-03.md
@@ -52,7 +52,7 @@ After the resource is created, select **Create a knowledge base** and set the fo
 
 - **Name**: kb-aml
 - **Description**: Synthetic AML / CFT / KYC corpus for Fraud Intelligence
-- **Chat completion model**: gpt-5-mini
+- **Chat completion model**: gpt-5-mini (or gpt-5.4-mini, new models are being added/delete to/from this configuration section)
 - **Retrieval reasoning effort**: Minimal
 - **Output mode**: Extractive data
 - **Retrieval instructions**: You have to always retrieve first the global policies and rules.

--- a/03-Azure/01-04-AI/07_Fraud_Intelligence/labautomation/lab-defaults.json
+++ b/03-Azure/01-04-AI/07_Fraud_Intelligence/labautomation/lab-defaults.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/MicroHack/refs/heads/main/lab-defaults-schema.json",
-  "groups": ["GHCPUsers"],
+  "groups": [],
   "deploymentType": "resourcegroup-with-subscriptionowner",
   "labsPerSubscription": 5,
   "preferredLocation": "swedencentral",

--- a/03-Azure/01-04-AI/07_Fraud_Intelligence/labautomation/lab-defaults.json
+++ b/03-Azure/01-04-AI/07_Fraud_Intelligence/labautomation/lab-defaults.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/MicroHack/refs/heads/main/lab-defaults-schema.json",
-  "groups": [],
+  "groups": ["GHCPUsers"],
   "deploymentType": "resourcegroup-with-subscriptionowner",
   "labsPerSubscription": 5,
   "preferredLocation": "swedencentral",

--- a/03-Azure/01-04-AI/07_Fraud_Intelligence/walkthrough/challenge-03/solution-03.md
+++ b/03-Azure/01-04-AI/07_Fraud_Intelligence/walkthrough/challenge-03/solution-03.md
@@ -52,7 +52,7 @@ After the resource is created, select **Create a knowledge base** and set the fo
 
 - **Name**: kb-aml
 - **Description**: Synthetic AML / CFT / KYC corpus for Fraud Intelligence
-- **Chat completion model**: gpt-5-mini
+- **Chat completion model**: gpt-5-mini (or gpt-5.4-mini, new models are being added/delete to/from this configuration section)
 - **Retrieval reasoning effort**: Minimal
 - **Output mode**: Extractive data
 - **Retrieval instructions**: You have to always retrieve first the global policies and rules.


### PR DESCRIPTION
This pull request makes minor updates to documentation and configuration related to the Fraud Intelligence labs. The main changes clarify the available chat completion models in the documentation and adjust the default lab group configuration.

Configuration update:

* The `groups` field in `labautomation/lab-defaults.json` was changed from `["GHCPUsers"]` to an empty array, meaning no default user groups are assigned for lab deployments.

Documentation improvements:

* In both the challenge instructions (`challenge-03.md`) and the solution walkthrough (`solution-03.md`), the description for the "Chat completion model" was updated to clarify that either `gpt-5-mini` or `gpt-5.4-mini` can be used, and that models may be added or removed from this configuration section. [[1]](diffhunk://#diff-1a04c73a9ea583ff07b7f992fcbd69d11fa98cd31f8ce307d40befd06cbd168eL55-R55) [[2]](diffhunk://#diff-18d86c33a42b0e61477ddf0313cd45cdc5b8c94d5e69afaf1091ddbb719297faL55-R55)