### PR TITLE
New prefferred locations added

### DIFF
--- a/03-Azure/01-04-AI/07_Fraud_Intelligence/labautomation/lab-defaults.json
+++ b/03-Azure/01-04-AI/07_Fraud_Intelligence/labautomation/lab-defaults.json
@@ -3,7 +3,7 @@
   "groups": ["GHCPUsers"],
   "deploymentType": "resourcegroup-with-subscriptionowner",
   "labsPerSubscription": 5,
-  "preferredLocation": "swedencentral",
+  "preferredLocation": "swedencentral, germanywestcentral, francecentral",
   "estimatedDailyCostsUsd": 5.0,
   "estimatedSharedDeploymentDailyCostsUsd": 0.0
 }


### PR DESCRIPTION
This pull request updates the default lab configuration to support multiple preferred deployment locations. The most important change is:

Configuration update:

* Expanded the `preferredLocation` field in `lab-defaults.json` to allow deployments in "swedencentral", "germanywestcentral", and "francecentral" instead of just "swedencentral".