### PR TITLE
Add more robust dependent resource sequence

### DIFF
--- a/03-Azure/01-04-AI/07_Fraud_Intelligence/labautomation/main.bicep
+++ b/03-Azure/01-04-AI/07_Fraud_Intelligence/labautomation/main.bicep
@@ -153,6 +153,9 @@ resource embeddingDeployment 'Microsoft.CognitiveServices/accounts/deployments@2
 resource chatDeployment 'Microsoft.CognitiveServices/accounts/deployments@2025-06-01' = {
 	parent: foundryAccount
 	name: 'gpt-5.6-luna'
+	dependsOn: [
+		foundryProject
+	]
 	properties: {
 		model: {
 			format: 'OpenAI'

--- a/03-Azure/01-04-AI/07_Fraud_Intelligence/labautomation/main.bicep
+++ b/03-Azure/01-04-AI/07_Fraud_Intelligence/labautomation/main.bicep
@@ -120,6 +120,9 @@ resource foundryAccount 'Microsoft.CognitiveServices/accounts@2025-06-01' = {
 resource foundryProject 'Microsoft.CognitiveServices/accounts/projects@2025-06-01' = {
 	parent: foundryAccount
 	name: foundryProjectName
+	dependsOn: [
+		foundryAccount
+	]
 	location: location
 	identity: {
 		type: 'SystemAssigned'


### PR DESCRIPTION
This pull request introduces dependency ordering improvements to the Azure Bicep deployment script for the Fraud Intelligence AI lab automation. The changes ensure that resources are deployed in the correct order, preventing potential deployment failures due to missing dependencies.

**Resource dependency management:**

* Added a `dependsOn` clause to the `foundryProject` resource to ensure it is created only after the `foundryAccount` resource is available.
* Added a `dependsOn` clause to the `chatDeployment` resource so that it waits for the `foundryProject` resource to be provisioned before deploying.